### PR TITLE
UI/deck list add DeckItem, and refactor separating DeckItemDetail composeable

### DIFF
--- a/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckItemKtTest.kt
+++ b/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckItemKtTest.kt
@@ -25,7 +25,7 @@ class DeckItemKtTest {
                 information = fakeDeckInformation,
                 onCardClick = {},
                 expanded = expanded,
-                onExpandClick = { expanded = !expanded },
+                onExpandedChange = { expanded = !expanded },
             )
         }
         val notExpandedIcon = composeTestRule.onNodeWithContentDescription("not expanded icon")
@@ -46,7 +46,7 @@ class DeckItemKtTest {
             DeckItem(
                 information = fakeDeckInformation,
                 expanded = expanded,
-                onExpandClick = { expanded = !expanded },
+                onExpandedChange = { expanded = !expanded },
                 onCardClick = {},
             )
         }

--- a/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckItemKtTest.kt
+++ b/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckItemKtTest.kt
@@ -22,17 +22,10 @@ class DeckItemKtTest {
             var expanded by remember { mutableStateOf(false) }
 
             DeckItem(
-                deckId = "",
+                information = fakeDeckInformation,
                 onCardClick = {},
-                rank = 1,
-                deckName = "deckName",
-                winRate = "winRate",
-                share = "share",
-                pokemonImageUrls = emptyList(),
                 expanded = expanded,
                 onExpandClick = { expanded = !expanded },
-                cost = 1990,
-                pokemonTypes = emptyList(),
             )
         }
         val notExpandedIcon = composeTestRule.onNodeWithContentDescription("not expanded icon")
@@ -51,17 +44,10 @@ class DeckItemKtTest {
             var expanded by remember { mutableStateOf(true) }
 
             DeckItem(
-                deckId = "",
-                rank = 1,
-                deckName = "deckName",
-                winRate = "winRate",
-                share = "share",
-                pokemonImageUrls = emptyList(),
+                information = fakeDeckInformation,
                 expanded = expanded,
                 onExpandClick = { expanded = !expanded },
                 onCardClick = {},
-                cost = 1990,
-                pokemonTypes = emptyList(),
             )
         }
         val notExpandedIcon = composeTestRule.onNodeWithContentDescription("not expanded icon")

--- a/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckListKtTest.kt
+++ b/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckListKtTest.kt
@@ -1,0 +1,35 @@
+package tcg.pocket.dex.tierdecks
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+class DeckListKtTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val sampleDeckItemsState =
+        fakeDecksInformation.map {
+            DeckItemState(it)
+        }
+
+    @Test
+    fun deckList_expandItem() {
+        composeTestRule.setContent {
+            DeckList(
+                deckItemsState = sampleDeckItemsState,
+                onExpandDeck = { itemState, expanded -> itemState.toggleExpanded() },
+                onDeckItemClick = {},
+            )
+        }
+
+        composeTestRule.onAllNodesWithContentDescription("not expanded icon").onFirst().performClick()
+
+        composeTestRule.onNodeWithContentDescription("expanded icon").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/MainActivity.kt
+++ b/app/src/main/java/tcg/pocket/dex/MainActivity.kt
@@ -7,17 +7,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import tcg.pocket.dex.tierdecks.DeckItem
-import tcg.pocket.dex.tierdecks.fakePokemonTypeChipDataset
-import tcg.pocket.dex.tierdecks.fakeSimpleUrl
+import tcg.pocket.dex.tierdecks.fakeDeckInformation
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 class MainActivity : ComponentActivity() {
@@ -29,18 +25,7 @@ class MainActivity : ComponentActivity() {
             TcgPocketDexTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     DeckItem(
-                        deckId = "deckId",
-                        rank = 1,
-                        deckName = "Mewtwo ex Gardevoir",
-                        winRate = "50.64%",
-                        share = "17.57%",
-                        pokemonImageUrls =
-                            listOf(
-                                fakeSimpleUrl(150),
-                                fakeSimpleUrl(282),
-                            ),
-                        cost = 1990,
-                        pokemonTypes = fakePokemonTypeChipDataset,
+                        information = fakeDeckInformation,
                         expanded = expanded,
                         onExpandClick = { expanded = !expanded },
                         onCardClick = {},
@@ -49,24 +34,5 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(
-    name: String,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier,
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TcgPocketDexTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/tcg/pocket/dex/MainActivity.kt
+++ b/app/src/main/java/tcg/pocket/dex/MainActivity.kt
@@ -5,11 +5,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import tcg.pocket.dex.tierdecks.DeckList
-import tcg.pocket.dex.tierdecks.fakeDecksInformation
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,11 +16,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             TcgPocketDexTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    DeckList(
-                        deckItems = fakeDecksInformation,
-                        onDeckItemClick = { },
-                        modifier = Modifier.padding(innerPadding),
-                    )
+
                 }
             }
         }

--- a/app/src/main/java/tcg/pocket/dex/MainActivity.kt
+++ b/app/src/main/java/tcg/pocket/dex/MainActivity.kt
@@ -7,13 +7,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import tcg.pocket.dex.tierdecks.DeckItem
-import tcg.pocket.dex.tierdecks.fakeDeckInformation
+import tcg.pocket.dex.tierdecks.DeckList
+import tcg.pocket.dex.tierdecks.fakeDecksInformation
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 class MainActivity : ComponentActivity() {
@@ -21,14 +17,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            var expanded by rememberSaveable { mutableStateOf(true) }
             TcgPocketDexTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    DeckItem(
-                        information = fakeDeckInformation,
-                        expanded = expanded,
-                        onExpandClick = { expanded = !expanded },
-                        onCardClick = {},
+                    DeckList(
+                        deckItems = fakeDecksInformation,
+                        onDeckItemClick = { },
                         modifier = Modifier.padding(innerPadding),
                     )
                 }

--- a/app/src/main/java/tcg/pocket/dex/MainActivity.kt
+++ b/app/src/main/java/tcg/pocket/dex/MainActivity.kt
@@ -5,8 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import tcg.pocket.dex.tierdecks.TierDecksScreen
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 class MainActivity : ComponentActivity() {
@@ -15,8 +16,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TcgPocketDexTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    TierDecksScreen()
                 }
             }
         }

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/DeckInformation.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/DeckInformation.kt
@@ -1,0 +1,21 @@
+package tcg.pocket.dex.tierdecks
+
+data class DeckInformation(
+    val simple: DeckSimpleInformation,
+    val detail: DeckDetailInformation,
+)
+
+data class DeckSimpleInformation(
+    val deckId: String,
+    val representativePokemonImageUrls: List<String>,
+    val rank: Int,
+    val deckName: String,
+    val winRate: String,
+    val share: String,
+)
+
+data class DeckDetailInformation(
+    val cost: Int,
+    val pokemonTypes: List<PokemonTypeChipData>,
+    val description: String,
+)

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItem.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItem.kt
@@ -44,8 +44,8 @@ fun DeckItem(
     Card(
         modifier =
             modifier
-                .padding(16.dp)
                 .fillMaxWidth()
+                .padding(4.dp)
                 .clickable { onCardClick(information.simple.deckId) },
         shape = RoundedCornerShape(8.dp),
     ) {
@@ -112,7 +112,7 @@ private fun DeckItemDetail(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.fillMaxWidth().padding(8.dp),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItem.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItem.kt
@@ -22,6 +22,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -37,7 +41,7 @@ import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 fun DeckItem(
     information: DeckInformation,
     expanded: Boolean = false,
-    onExpandClick: () -> Unit,
+    onExpandedChange: (Boolean) -> Unit,
     onCardClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -78,7 +82,7 @@ fun DeckItem(
 
                 IconButton(
                     modifier = Modifier.padding(0.dp),
-                    onClick = onExpandClick,
+                    onClick = { onExpandedChange(expanded) },
                 ) {
                     if (expanded) {
                         Icon(
@@ -252,13 +256,14 @@ private fun DeckItemInfoContentPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun DeckItemPreview(
-    @PreviewParameter(DeckCardPreviewParameters::class) expanded: Boolean,
+    @PreviewParameter(DeckCardPreviewParameters::class) initialExpanded: Boolean,
 ) {
     TcgPocketDexTheme {
+        var expanded by remember { mutableStateOf(initialExpanded) }
         DeckItem(
             information = fakeDeckInformation,
             expanded = expanded,
-            onExpandClick = {},
+            onExpandedChange = { expanded = !expanded },
             onCardClick = {},
         )
     }

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItem.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItem.kt
@@ -1,5 +1,6 @@
 package tcg.pocket.dex.tierdecks
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -34,14 +35,7 @@ import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable
 fun DeckItem(
-    deckId: String,
-    rank: Int,
-    deckName: String,
-    winRate: String,
-    share: String,
-    pokemonImageUrls: List<String>,
-    cost: Int,
-    pokemonTypes: List<PokemonTypeChipData>,
+    information: DeckInformation,
     expanded: Boolean = false,
     onExpandClick: () -> Unit,
     onCardClick: (String) -> Unit,
@@ -52,7 +46,7 @@ fun DeckItem(
             modifier
                 .padding(16.dp)
                 .fillMaxWidth()
-                .clickable { onCardClick(deckId) },
+                .clickable { onCardClick(information.simple.deckId) },
         shape = RoundedCornerShape(8.dp),
     ) {
         Column(
@@ -66,19 +60,19 @@ fun DeckItem(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 RankText(
-                    rank = rank,
+                    rank = information.simple.rank,
                     modifier = Modifier.padding(end = 8.dp),
                 )
 
                 PokemonImageList(
-                    pokemonImageUrls = pokemonImageUrls,
+                    pokemonImageUrls = information.simple.representativePokemonImageUrls,
                     modifier = Modifier,
                 )
 
                 DeckItemInfoContent(
-                    deckName = deckName,
-                    winRate = winRate,
-                    share = share,
+                    deckName = information.simple.deckName,
+                    winRate = information.simple.winRate,
+                    share = information.simple.share,
                     modifier = Modifier.weight(1f),
                 )
 
@@ -100,10 +94,10 @@ fun DeckItem(
                 }
             }
 
-            if (expanded) {
+            AnimatedVisibility(expanded) {
                 DeckItemDetail(
-                    cost = cost,
-                    pokemonTypes = pokemonTypes,
+                    cost = information.detail.cost,
+                    pokemonTypes = information.detail.pokemonTypes,
                     modifier = Modifier,
                 )
             }
@@ -262,21 +256,10 @@ private fun DeckItemPreview(
 ) {
     TcgPocketDexTheme {
         DeckItem(
-            deckId = "",
-            rank = 1,
-            deckName = "Mewtwo ex Gardevoir",
-            winRate = "50.67%",
-            share = "17.57%",
-            pokemonImageUrls =
-                listOf(
-                    fakeSimpleUrl(150),
-                    fakeSimpleUrl(282),
-                ),
+            information = fakeDeckInformation,
             expanded = expanded,
             onExpandClick = {},
             onCardClick = {},
-            cost = 0,
-            pokemonTypes = fakePokemonTypeChipDataset,
         )
     }
 }

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItemState.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/DeckItemState.kt
@@ -1,0 +1,17 @@
+package tcg.pocket.dex.tierdecks
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+class DeckItemState(
+    val content: DeckInformation,
+    initialExpanded: Boolean = false,
+) {
+    var expanded: Boolean by mutableStateOf(initialExpanded)
+        private set
+
+    fun toggleExpanded() {
+        expanded = !expanded
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/DeckList.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/DeckList.kt
@@ -5,10 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -16,7 +12,8 @@ import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable
 fun DeckList(
-    deckItems: List<DeckInformation>,
+    deckItemsState: List<DeckItemState>,
+    onExpandDeck: (DeckItemState, Boolean) -> Unit,
     onDeckItemClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -27,15 +24,14 @@ fun DeckList(
                 .padding(8.dp),
     ) {
         items(
-            items = deckItems,
-            key = { deckItem -> deckItem.simple.deckId },
-        ) { deckItem ->
-            var expanded by rememberSaveable { mutableStateOf(false) }
+            items = deckItemsState,
+            key = { deckItem -> deckItem.content.simple.deckId },
+        ) { deckItemState ->
 
             DeckItem(
-                information = deckItem,
-                expanded = expanded,
-                onExpandClick = { expanded = !expanded },
+                information = deckItemState.content,
+                expanded = deckItemState.expanded,
+                onExpandedChange = { expanded -> onExpandDeck(deckItemState, expanded) },
                 onCardClick = onDeckItemClick,
             )
         }
@@ -47,8 +43,9 @@ fun DeckList(
 private fun DeckListPreview() {
     TcgPocketDexTheme {
         DeckList(
-            deckItems = fakeDecksInformation,
+            deckItemsState = fakeDecksInformation.map(::DeckItemState),
             onDeckItemClick = { },
+            onExpandDeck = { deckItemStata, _ -> },
         )
     }
 }

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/DeckList.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/DeckList.kt
@@ -1,0 +1,54 @@
+package tcg.pocket.dex.tierdecks
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun DeckList(
+    deckItems: List<DeckInformation>,
+    onDeckItemClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+    ) {
+        items(
+            items = deckItems,
+            key = { deckItem -> deckItem.simple.deckId },
+        ) { deckItem ->
+            var expanded by rememberSaveable { mutableStateOf(false) }
+
+            DeckItem(
+                information = deckItem,
+                expanded = expanded,
+                onExpandClick = { expanded = !expanded },
+                onCardClick = onDeckItemClick,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DeckListPreview() {
+    TcgPocketDexTheme {
+        DeckList(
+            deckItems = fakeDecksInformation,
+            onDeckItemClick = { },
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
@@ -67,9 +67,7 @@ val fakeTypesUrl =
         "https://static.dotgg.gg/pokepocket/icons/fire.png",
         "https://static.dotgg.gg/pokepocket/icons/water.png",
         "https://static.dotgg.gg/pokepocket/icons/grass.png",
-        "https://static.dotgg.gg/pokepocket/icons/electric.png",
         "https://static.dotgg.gg/pokepocket/icons/dragon.png",
-        "https://static.dotgg.gg/pokepocket/icons/normal.png",
         "https://static.dotgg.gg/pokepocket/icons/fighting.png",
     )
 

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
@@ -1,5 +1,6 @@
 package tcg.pocket.dex.tierdecks
 
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import tcg.pocket.dex.R
 
 val temporalPokemonPlaceholderDrawable: Int = R.drawable.tcg_pocket_unknown
@@ -60,3 +61,49 @@ val fakeDeckInformation =
                 description = fakeTierDeckDescription,
             ),
     )
+
+val fakeTypesUrl =
+    listOf(
+        "https://static.dotgg.gg/pokepocket/icons/fire.png",
+        "https://static.dotgg.gg/pokepocket/icons/water.png",
+        "https://static.dotgg.gg/pokepocket/icons/grass.png",
+        "https://static.dotgg.gg/pokepocket/icons/electric.png",
+        "https://static.dotgg.gg/pokepocket/icons/dragon.png",
+        "https://static.dotgg.gg/pokepocket/icons/normal.png",
+        "https://static.dotgg.gg/pokepocket/icons/fighting.png",
+    )
+
+val fakeDecksInformation =
+    List(15) { index ->
+        DeckInformation(
+            simple =
+                DeckSimpleInformation(
+                    deckId = "$index",
+                    representativePokemonImageUrls =
+                        listOf(
+                            "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${index + 1}.png",
+                            "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${index + 2}.png",
+                        ),
+                    rank = index + 1,
+                    deckName = "Deck Name $index",
+                    winRate = "${50 + index % 10}.${index % 10}%",
+                    share = "${10 + index % 5}.${index % 5}%",
+                ),
+            detail =
+                DeckDetailInformation(
+                    cost = 3 + index % 5,
+                    pokemonTypes =
+                        listOf(
+                            PokemonTypeChipData(
+                                imageUrl = fakeTypesUrl.random(),
+                                count = index % 3 + 1,
+                            ),
+                            PokemonTypeChipData(
+                                imageUrl = fakeTypesUrl.random(),
+                                count = index % 2 + 1,
+                            ),
+                        ),
+                    description = LoremIpsum(20).values.joinToString(),
+                ),
+        )
+    }

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
@@ -36,3 +36,27 @@ val fakeTierDeckDescription =
         "knocking out almost any Pokemon with 1 hit."
 
 fun fakeSimpleUrl(dexNumber: Int): String = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/$dexNumber.png"
+
+val fakeDeckInformation =
+    DeckInformation(
+        simple =
+            DeckSimpleInformation(
+                deckId = "deckId",
+                representativePokemonImageUrls =
+                    listOf(
+                        fakeSimpleUrl(150),
+                        fakeSimpleUrl(282),
+                    ),
+                rank = 1,
+                deckName = "Deck Name",
+                winRate = "53.64%",
+                share = "17.52%",
+            ),
+        detail =
+            DeckDetailInformation(
+                cost = 100,
+//        pokemonTypes = fakePokemonTypeChipDataset,
+                pokemonTypes = listOf(fakeWaterPokemonTypeChipData),
+                description = fakeTierDeckDescription,
+            ),
+    )

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/TierDecksScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/TierDecksScreen.kt
@@ -1,0 +1,31 @@
+package tcg.pocket.dex.tierdecks
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.tooling.preview.Preview
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+// TODO: viewModel
+val deckItemsState =
+    mutableStateListOf<DeckItemState>().apply {
+        addAll(fakeDecksInformation.map { DeckItemState(it) })
+    }
+
+@Composable
+fun TierDecksScreen() {
+    DeckList(
+        deckItemsState = deckItemsState,
+        onExpandDeck = { deckItemState, expanded ->
+            deckItemState.toggleExpanded()
+        },
+        onDeckItemClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun TireDecksScreenPreview() {
+    TcgPocketDexTheme {
+        TierDecksScreen()
+    }
+}


### PR DESCRIPTION
Added an expandable detail section to the DeckItem component for displaying additional deck information such as cost and Pokémon types.
Refactored the DeckItem implementation to separate the expanded content into a reusable DeckItemDetail composable.
