### PR TITLE
UI/card detail: CardDetailScreen 

### DIFF
--- a/app/src/main/java/tcg/pocket/dex/PocketDexApp.kt
+++ b/app/src/main/java/tcg/pocket/dex/PocketDexApp.kt
@@ -15,9 +15,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import tcg.pocket.dex.allcards.AllCardsScreen
+import tcg.pocket.dex.allcards.CardDetailScreen
 import tcg.pocket.dex.deckdetail.DeckDetailScreen
 import tcg.pocket.dex.extensionpacks.ExtensionPacksScreen
 import tcg.pocket.dex.navigation.AllCards
+import tcg.pocket.dex.navigation.CardDetail
 import tcg.pocket.dex.navigation.ExpansionPacks
 import tcg.pocket.dex.navigation.Search
 import tcg.pocket.dex.navigation.Setting
@@ -35,9 +37,15 @@ import tcg.pocket.dex.tierdecks.fakeCardsData
 import tcg.pocket.dex.tierdecks.fakeDecksInformation
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
+// TODO: move to viewmodel
 val deckItemsState =
     mutableStateListOf<DeckItemState>().apply {
-        addAll(fakeDecksInformation.map { DeckItemState(it) })
+        addAll(fakeDecksInformation.map(::DeckItemState))
+    }
+
+val relatedDeckItemState =
+    mutableStateListOf<DeckItemState>().apply {
+        addAll(fakeDecksInformation.subList(0, 4).map(::DeckItemState))
     }
 
 @Composable
@@ -111,7 +119,9 @@ fun PocketDexApp(openUrl: () -> Unit = {}) {
                 composable(route = AllCards.route) {
                     AllCardsScreen(
                         cards = fakeCardsData,
-                        onCardClick = { /* todo */ },
+                        onCardClick = {
+                            navController.navigate(CardDetail.routeWithArgs(it))
+                        },
                     )
                 }
                 composable(route = ExpansionPacks.route) {
@@ -136,6 +146,22 @@ fun PocketDexApp(openUrl: () -> Unit = {}) {
                         "expansion_packs" -> SearchScreenForExpansionPacks()
                         else -> error("Unknown search type: $searchType")
                     }
+                }
+                composable(
+                    route = CardDetail.routeWithArgs,
+                    arguments = CardDetail.arguments,
+                ) { navBackStackEntry ->
+                    val cardId = navBackStackEntry.arguments?.getString(CardDetail.CARD_DETAIL_ARG)
+                    CardDetailScreen(
+                        cardId = cardId,
+                        deckItemsState = relatedDeckItemState,
+                        onExpandDeck = { deckItemState, _ ->
+                            deckItemState.toggleExpanded()
+                        },
+                        onDeckItemClick = { deckId ->
+                            navController.navigate(TierDeckDetail.routeWithArgs(deckId))
+                        },
+                    )
                 }
             }
         }

--- a/app/src/main/java/tcg/pocket/dex/allcards/AllCardScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/AllCardScreen.kt
@@ -1,42 +1,21 @@
 package tcg.pocket.dex.allcards
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import tcg.pocket.dex.tierdecks.fakeCardsData
-import tcg.pocket.dex.tierdecks.temporalPokemonCardPlaceholderDrawable
-import tcg.pocket.dex.tierdecks.temporalPokemonCardRarityPlaceholderDrawable
-import tcg.pocket.dex.tierdecks.temporalPokemonTypePlaceholderDrawable
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable
 fun AllCardsScreen(
     modifier: Modifier = Modifier,
     cards: List<CardData>,
-    onCardClick: (CardData) -> Unit,
+    onCardClick: (String) -> Unit = {},
 ) {
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = 100.dp),
@@ -47,62 +26,7 @@ fun AllCardsScreen(
     ) {
         items(cards.size) { index ->
             val card = cards[index]
-            CardItem(card, onClick = { onCardClick(card) })
-        }
-    }
-}
-
-@Composable
-fun CardItem(
-    card: CardData,
-    onClick: () -> Unit,
-) {
-    Card(
-        modifier =
-            Modifier
-                .padding(8.dp)
-                .fillMaxWidth()
-                .clickable(onClick = onClick),
-        shape = RoundedCornerShape(8.dp),
-        elevation = CardDefaults.cardElevation(4.dp),
-    ) {
-        Column(modifier = Modifier.padding(8.dp)) {
-            AsyncImage(
-                model = card.imageUrl,
-                contentDescription = card.name,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(0.7f),
-                contentScale = ContentScale.Crop,
-                placeholder = painterResource(temporalPokemonCardPlaceholderDrawable),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = card.name,
-                style = MaterialTheme.typography.titleSmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                AsyncImage(
-                    model = card.rarityUrl,
-                    contentDescription = "Rarity",
-                    placeholder = painterResource(temporalPokemonCardRarityPlaceholderDrawable),
-                )
-                AsyncImage(
-                    model = card.typeUrl,
-                    contentDescription = "Type",
-                    placeholder = painterResource(temporalPokemonTypePlaceholderDrawable),
-                )
-            }
+            CardItem(card, onClick = { onCardClick(card.Id) })
         }
     }
 }
@@ -130,6 +54,7 @@ private fun CardItemPreview() {
 }
 
 data class CardData(
+    val Id: String = "",
     val name: String,
     val imageUrl: String,
     val rarityUrl: String,

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardAttribute.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardAttribute.kt
@@ -1,0 +1,210 @@
+package tcg.pocket.dex.allcards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import tcg.pocket.dex.tierdecks.fakeCardDetail
+import tcg.pocket.dex.tierdecks.temporalPokemonCardRarityPlaceholderDrawable
+import tcg.pocket.dex.tierdecks.temporalPokemonTypePlaceholderDrawable
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun CardAttribute(
+    cardDetail: CardDetail,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 2.dp,
+        shadowElevation = 2.dp,
+    ) {
+        Column {
+            PokemonCardRarity(cardDetail)
+            PokemonType(cardDetail)
+            PokemonWeakness(cardDetail)
+            PokemonHp(cardDetail)
+            PokemonRetreatCost(cardDetail)
+            PokemonEvolutionStage(cardDetail)
+        }
+    }
+}
+
+@Composable
+private fun PokemonCardRarity(
+    cardDetail: CardDetail,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Rarity:",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        AsyncImage(
+            model = cardDetail.rarityUrl,
+            contentDescription = "Rarity",
+            placeholder =
+                painterResource(
+                    temporalPokemonCardRarityPlaceholderDrawable,
+                ),
+        )
+    }
+}
+
+@Composable
+private fun PokemonType(
+    cardDetail: CardDetail,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Type:",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = cardDetail.type,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        AsyncImage(
+            model = cardDetail.typeImageUrl,
+            contentDescription = "Type",
+            placeholder = painterResource(temporalPokemonTypePlaceholderDrawable),
+        )
+    }
+}
+
+@Composable
+private fun PokemonWeakness(
+    cardDetail: CardDetail,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Weakness:",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        AsyncImage(
+            model = cardDetail.weaknessTypeUrl,
+            contentDescription = "Weakness",
+            placeholder = painterResource(temporalPokemonTypePlaceholderDrawable),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = cardDetail.weakness,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Composable
+private fun PokemonHp(
+    cardDetail: CardDetail,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "HP:",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = cardDetail.hp,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Composable
+private fun PokemonRetreatCost(
+    cardDetail: CardDetail,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Retreat Cost:",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = cardDetail.retreatCost.toString(),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Composable
+private fun PokemonEvolutionStage(cardDetail: CardDetail) {
+    Row(
+        modifier =
+            Modifier
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Evolution Stage:",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = cardDetail.stage.toString(),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CardAttributePreview() {
+    TcgPocketDexTheme {
+        CardAttribute(
+            cardDetail = fakeCardDetail,
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetail.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetail.kt
@@ -1,0 +1,24 @@
+package tcg.pocket.dex.allcards
+
+data class CardDetail(
+    val name: String,
+    val rarity: String,
+    val rarityUrl: String,
+    val type: String,
+    val typeImageUrl: String,
+    val weakness: String,
+    val weaknessType: String,
+    val weaknessTypeUrl: String,
+    val hp: String,
+    val retreatCost: Int,
+    val stage: Int,
+    val description: String,
+    val imageUrl: String,
+    val pokemonMoves: List<PokemonMove>,
+)
+
+data class DeckDetails(
+    val name: String,
+    val type: String,
+    val imageUrl: String,
+)

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetailHeader.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetailHeader.kt
@@ -1,0 +1,63 @@
+package tcg.pocket.dex.allcards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import tcg.pocket.dex.tierdecks.fakeCardDetail
+import tcg.pocket.dex.tierdecks.temporalPokemonCardPlaceholderDrawable
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun CardDetailHeader(
+    cardDetail: CardDetail,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AsyncImage(
+                model = cardDetail.imageUrl,
+                contentDescription = null,
+                modifier =
+                    Modifier
+                        .weight(0.8f),
+                placeholder = painterResource(temporalPokemonCardPlaceholderDrawable),
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+
+            CardAttribute(
+                cardDetail = cardDetail,
+                modifier = Modifier.weight(1.2f),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        PokemonMoves(
+            pokemonMoves = cardDetail.pokemonMoves,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CardDetailHeaderPreview() {
+    TcgPocketDexTheme {
+        CardDetailHeader(
+            cardDetail = fakeCardDetail,
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
@@ -1,0 +1,81 @@
+package tcg.pocket.dex.allcards
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.tierdecks.DeckItemState
+import tcg.pocket.dex.tierdecks.fakeCardDetail
+import tcg.pocket.dex.tierdecks.fakeCardsData
+import tcg.pocket.dex.tierdecks.fakeDecksInformation
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+val tempCardDetail = fakeCardDetail
+
+// TODO: constructor param viewmodel
+@Composable
+fun CardDetailScreen(
+    cardId: String? = "",
+    deckItemsState: List<DeckItemState>,
+    onExpandDeck: (DeckItemState, Boolean) -> Unit,
+    onDeckItemClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // TODO: fetch the data from viewmodel
+    val cardDetail = tempCardDetail
+    val relatedCards = fakeCardsData.subList(0, 5)
+    LazyColumn(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(16.dp),
+    ) {
+        item {
+            CardDetailHeader(
+                cardDetail = cardDetail,
+                modifier = modifier,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            RelatedCardsSection(
+                relatedCards = relatedCards,
+                modifier = modifier,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        item {
+            RelatedDecksSection(
+                deckItemsState = deckItemsState,
+                onExpandDeck = onExpandDeck,
+                onDeckItemClick = onDeckItemClick,
+                modifier = modifier,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CardDetailScreenPreview() {
+    TcgPocketDexTheme {
+        CardDetailScreen(
+            cardId = "1",
+            deckItemsState = fakeDecksInformation.map(::DeckItemState),
+            onDeckItemClick = { },
+            onExpandDeck = { deckItemStata, _ -> },
+        )
+    }
+}
+
+data class Energy(
+    val type: String,
+    val typeUrl: String,
+)
+
+private const val TAG = "CardDetailScreen"

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardItem.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardItem.kt
@@ -1,0 +1,101 @@
+package tcg.pocket.dex.allcards
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import tcg.pocket.dex.tierdecks.fakeCardsData
+import tcg.pocket.dex.tierdecks.temporalPokemonCardPlaceholderDrawable
+import tcg.pocket.dex.tierdecks.temporalPokemonCardRarityPlaceholderDrawable
+import tcg.pocket.dex.tierdecks.temporalPokemonTypePlaceholderDrawable
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun CardItem(
+    card: CardData,
+    onClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(4.dp)
+                .clickable(onClick = {
+                    onClick(card.Id)
+                }),
+        shape = RoundedCornerShape(8.dp),
+        elevation = CardDefaults.cardElevation(4.dp),
+    ) {
+        Column(modifier = Modifier.padding(8.dp)) {
+            AsyncImage(
+                model = card.imageUrl,
+                contentDescription = card.name,
+                modifier =
+                    Modifier
+                        .fillMaxWidth(),
+                contentScale = ContentScale.Fit,
+                placeholder = painterResource(temporalPokemonCardPlaceholderDrawable),
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = card.name,
+                style =
+                    MaterialTheme.typography.titleSmall.copy(
+                        fontWeight = FontWeight.Bold,
+                    ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                AsyncImage(
+                    model = card.rarityUrl,
+                    contentDescription = "Rarity",
+                    placeholder = painterResource(temporalPokemonCardRarityPlaceholderDrawable),
+                )
+                AsyncImage(
+                    model = card.typeUrl,
+                    contentDescription = "Type",
+                    placeholder = painterResource(temporalPokemonTypePlaceholderDrawable),
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CardItemPreview() {
+    TcgPocketDexTheme {
+        CardItem(
+            card = fakeCardsData[0],
+            onClick = {},
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
@@ -1,0 +1,111 @@
+package tcg.pocket.dex.allcards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import tcg.pocket.dex.tierdecks.fakeCardDetail
+import tcg.pocket.dex.tierdecks.temporalPokemonTypePlaceholderDrawable
+import tcg.pocket.dex.ui.theme.ChipSize
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun PokemonMoves(
+    pokemonMoves: List<PokemonMove>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Surface(
+            tonalElevation = 2.dp,
+            shadowElevation = 2.dp,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+        ) {
+            Text(
+                text = "Moves",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(4.dp),
+            )
+        }
+
+        Surface(
+            tonalElevation = 2.dp,
+            shadowElevation = 2.dp,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column {
+                pokemonMoves.forEach { move ->
+                    Column(
+                        modifier = Modifier.padding(8.dp),
+                    ) {
+                        Row {
+                            move.energy.forEach { energy ->
+                                AsyncImage(
+                                    model = energy.typeUrl,
+                                    contentDescription = energy.type,
+                                    modifier = Modifier.size(ChipSize.Small),
+                                    placeholder =
+                                        painterResource(
+                                            temporalPokemonTypePlaceholderDrawable,
+                                        ),
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = move.name,
+                            )
+                            Text(
+                                text = move.damage.toString(),
+                                modifier = Modifier.weight(1f),
+                                textAlign = TextAlign.End,
+                            )
+                        }
+
+                        if (move.hasDescription) {
+                            Text(
+                                text = move.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                textAlign = TextAlign.Justify,
+                                modifier = Modifier.padding(8.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PokemonMovesPreview() {
+    TcgPocketDexTheme {
+        PokemonMoves(
+            pokemonMoves = fakeCardDetail.pokemonMoves,
+        )
+    }
+}
+
+data class PokemonMove(
+    val name: String,
+    val damage: Int,
+    val energy: List<Energy>,
+    val description: String,
+) {
+    val hasDescription: Boolean
+        get() = description.isNotEmpty()
+}

--- a/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -37,7 +38,10 @@ fun PokemonMoves(
         ) {
             Text(
                 text = "Moves",
-                style = MaterialTheme.typography.titleMedium,
+                style =
+                    MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                    ),
                 modifier = Modifier.padding(4.dp),
             )
         }

--- a/app/src/main/java/tcg/pocket/dex/allcards/RelatedCardsSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/RelatedCardsSection.kt
@@ -1,0 +1,75 @@
+package tcg.pocket.dex.allcards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.tierdecks.fakeCardsData
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun RelatedCardsSection(
+    relatedCards: List<CardData>,
+    onCardClick: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Surface(
+            tonalElevation = 2.dp,
+            shadowElevation = 2.dp,
+            modifier =
+                Modifier
+                    .fillMaxWidth(),
+            shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+        ) {
+            Text(
+                text = "Related Cards",
+                style =
+                    MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                    ),
+                modifier = Modifier.padding(4.dp),
+            )
+        }
+        Surface(
+            tonalElevation = 2.dp,
+            shadowElevation = 2.dp,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp),
+        ) {
+            LazyRow {
+                items(relatedCards) { card ->
+                    Column {
+                        CardItem(
+                            card = card,
+                            onClick = onCardClick,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RelatedCardSectionPreview() {
+    TcgPocketDexTheme {
+        RelatedCardsSection(
+            relatedCards = fakeCardsData.subList(0, 5),
+            onCardClick = {},
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/allcards/RelatedDecksSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/RelatedDecksSection.kt
@@ -1,0 +1,64 @@
+package tcg.pocket.dex.allcards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.component.PocketDexSectionHeader
+import tcg.pocket.dex.tierdecks.DeckItem
+import tcg.pocket.dex.tierdecks.DeckItemState
+import tcg.pocket.dex.tierdecks.fakeDecksInformation
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun RelatedDecksSection(
+    deckItemsState: List<DeckItemState>,
+    onExpandDeck: (DeckItemState, Boolean) -> Unit,
+    onDeckItemClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column {
+        PocketDexSectionHeader(
+            text = "Related Decks",
+            modifier = modifier,
+        )
+        Surface(
+            tonalElevation = 2.dp,
+            shadowElevation = 2.dp,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp),
+        ) {
+            Column {
+                deckItemsState.forEach { deckItemState ->
+                    DeckItem(
+                        information = deckItemState.content,
+                        expanded = deckItemState.expanded,
+                        onExpandedChange = { expanded ->
+                            onExpandDeck(deckItemState, expanded)
+                        },
+                        onCardClick = onDeckItemClick,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RelatedDecksContentPreview() {
+    TcgPocketDexTheme {
+        RelatedDecksSection(
+            deckItemsState = fakeDecksInformation.map(::DeckItemState),
+            onDeckItemClick = { },
+            onExpandDeck = { deckItemStata, _ -> },
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/component/PocketDexSectionHeader.kt
+++ b/app/src/main/java/tcg/pocket/dex/component/PocketDexSectionHeader.kt
@@ -1,0 +1,46 @@
+package tcg.pocket.dex.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun PocketDexSectionHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        tonalElevation = 2.dp,
+        shadowElevation = 2.dp,
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+    ) {
+        Text(
+            text = text,
+            style =
+                MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+            modifier = Modifier.padding(4.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PocketDexSectionHeaderPreview() {
+    TcgPocketDexTheme {
+        PocketDexSectionHeader(
+            text = "Related Decks",
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/navigation/PocketDexDestination.kt
+++ b/app/src/main/java/tcg/pocket/dex/navigation/PocketDexDestination.kt
@@ -66,4 +66,17 @@ object Setting : PocketDexDestination {
     override val route: String = "setting"
 }
 
+object CardDetail : PocketDexDestination {
+    override val route: String = "card"
+    const val CARD_DETAIL_ARG = "card_detail"
+    val routeWithArgs = "$route/{$CARD_DETAIL_ARG}"
+
+    val arguments =
+        listOf(
+            navArgument(CARD_DETAIL_ARG) { type = NavType.StringType },
+        )
+
+    fun routeWithArgs(cardId: String): String = "$route/$cardId"
+}
+
 val bottomBarScreens = listOf(AllCards, TierDecks, ExpansionPacks)

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/FakeData.kt
@@ -3,6 +3,9 @@ package tcg.pocket.dex.tierdecks
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import tcg.pocket.dex.R
 import tcg.pocket.dex.allcards.CardData
+import tcg.pocket.dex.allcards.CardDetail
+import tcg.pocket.dex.allcards.Energy
+import tcg.pocket.dex.allcards.PokemonMove
 
 val temporalPokemonPlaceholderDrawable: Int = R.drawable.tcg_pocket_unknown
 val temporalPokemonCardPlaceholderDrawable: Int = R.drawable.pocket_dex_card_image
@@ -200,4 +203,70 @@ val fakeCardsData =
             rarityUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/RarityIcon_RR.png?height=40",
             typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Lightning.png?width=40&height=40",
         ),
+    )
+
+val fakeCardDetail =
+    CardDetail(
+        name = "Venusaur ex",
+        rarity = "★ ★ ★",
+        rarityUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/RarityIcon_RR.png?height=40",
+        type = "Grass",
+        typeImageUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Grass.png?width=40&height=40",
+        weakness = "+20",
+        weaknessType = "Fire",
+        weaknessTypeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Fire.png?width=40&height=40",
+        hp = "150",
+        retreatCost = 3,
+        stage = 1,
+        description = "Psychic Sphere: 50\nPsydrive: 150",
+        imageUrl =
+            "https://assets.pokemon-zone.com/game-assets/" +
+                "CardPreviews/cPK_10_000040_00_FUSHIGIBANAex_RR.webp",
+        pokemonMoves =
+            listOf(
+                PokemonMove(
+                    name = "Razor Leaf",
+                    damage = 50,
+                    energy =
+                        listOf(
+                            Energy(
+                                type = "Grass",
+                                typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Grass.png?width=40&height=40",
+                            ),
+                            Energy(
+                                type = "Normal",
+                                typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Colorless.png?width=40&height=40",
+                            ),
+                            Energy(
+                                type = "Normal",
+                                typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Colorless.png?width=40&height=40",
+                            ),
+                        ),
+                    description = "",
+                ),
+                PokemonMove(
+                    name = "Giant Bloom",
+                    damage = 100,
+                    energy =
+                        listOf(
+                            Energy(
+                                type = "Grass",
+                                typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Grass.png?width=40&height=40",
+                            ),
+                            Energy(
+                                type = "Grass",
+                                typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Grass.png?width=40&height=40",
+                            ),
+                            Energy(
+                                type = "Normal",
+                                typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Colorless.png?width=40&height=40",
+                            ),
+                            Energy(
+                                type = "Normal",
+                                typeUrl = "https://static.mana.wiki/tcgwiki-pokemonpocket/TypeIcon_Colorless.png?width=40&height=40",
+                            ),
+                        ),
+                    description = "Heal 30 damage from this Pokémon.",
+                ),
+            ),
     )


### PR DESCRIPTION
## Work Video
NO

## Work Details
* CardDetailScreen Implementation
  * CardDetailHeader: Separated the header section for better maintainability.
  * PokemonMoves: Implemented a dedicated composable for Pokémon move details.
  * CardAttribute: Displays rarity, type, weakness, HP, retreat cost, and stage.
  * RelatedCardsSection: Now reuses the CardItem composable for consistency.
  * RelatedDecksSection: Introduced a new composable that reuses PocketDexSectionHeader for section headers.
  * PocketDexSectionHeader: Created a common section header component for use across different sections.

## PR Points
* Unit tests cover only validation.
* Each object does not hold too many responsibilities.

## 🚀 Next Feature
* CardDetailScreen is implemented but does not yet receive parameters from ViewModel.
* Improved composability by extracting reusable UI components (PocketDexSectionHeader, DeckList)

🚀 Next Feature
* Extract and refactor common UI components for broader reuse across screens.
* Integrate ViewModel with CardDetailScreen to manage state and data.
* Improve the styling and layout of CardDetailScreen for a better user experience.
