### PR TITLE
Refactor/component reuse: Extract Reusable UI Components for Card Detail

### DIFF
--- a/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckItemKtTest.kt
+++ b/app/src/androidTest/java/tcg/pocket/dex/tierdecks/DeckItemKtTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import org.junit.Rule
 import org.junit.Test
+import tcg.pocket.dex.component.DeckItem
 
 class DeckItemKtTest {
     @get:Rule

--- a/app/src/main/java/tcg/pocket/dex/allcards/AllCardScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/AllCardScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.component.CardItem
 import tcg.pocket.dex.tierdecks.fakeCardsData
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetail.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetail.kt
@@ -16,9 +16,3 @@ data class CardDetail(
     val imageUrl: String,
     val pokemonMoves: List<PokemonMove>,
 )
-
-data class DeckDetails(
-    val name: String,
-    val type: String,
-    val imageUrl: String,
-)

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetailMetaDataSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetailMetaDataSection.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,7 +17,7 @@ import tcg.pocket.dex.tierdecks.temporalPokemonCardPlaceholderDrawable
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable
-fun CardDetailHeader(
+fun CardDetailMetaDataSection(
     cardDetail: CardDetail,
     modifier: Modifier = Modifier,
 ) {
@@ -42,21 +41,14 @@ fun CardDetailHeader(
                 modifier = Modifier.weight(1.2f),
             )
         }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        PokemonMoves(
-            pokemonMoves = cardDetail.pokemonMoves,
-            modifier = Modifier.fillMaxWidth(),
-        )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun CardDetailHeaderPreview() {
+private fun CardDetailMetaDataSectionPreview() {
     TcgPocketDexTheme {
-        CardDetailHeader(
+        CardDetailMetaDataSection(
             cardDetail = fakeCardDetail,
         )
     }

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
@@ -44,7 +44,7 @@ fun CardDetailScreen(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            PokemonMoves(
+            PokemonMovesSection(
                 pokemonMoves = cardDetail.pokemonMoves,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
@@ -42,20 +42,20 @@ fun CardDetailScreen(
                 modifier = modifier,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
             PokemonMoves(
                 pokemonMoves = cardDetail.pokemonMoves,
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
             RelatedCardsSection(
                 relatedCards = relatedCards,
                 modifier = modifier,
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
         }
 
         item {

--- a/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/CardDetailScreen.kt
@@ -2,6 +2,7 @@ package tcg.pocket.dex.allcards
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -36,10 +37,18 @@ fun CardDetailScreen(
                 .padding(16.dp),
     ) {
         item {
-            CardDetailHeader(
+            CardDetailMetaDataSection(
                 cardDetail = cardDetail,
                 modifier = modifier,
             )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            PokemonMoves(
+                pokemonMoves = cardDetail.pokemonMoves,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
             Spacer(modifier = Modifier.height(16.dp))
 
             RelatedCardsSection(

--- a/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
@@ -50,9 +50,9 @@ fun PokemonMoves(
                                     contentDescription = energy.type,
                                     modifier = Modifier.size(ChipSize.Small),
                                     placeholder =
-                                    painterResource(
-                                        temporalPokemonTypePlaceholderDrawable,
-                                    ),
+                                        painterResource(
+                                            temporalPokemonTypePlaceholderDrawable,
+                                        ),
                                 )
                             }
                             Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/PokemonMoves.kt
@@ -7,18 +7,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import tcg.pocket.dex.component.PocketDexSectionHeader
 import tcg.pocket.dex.tierdecks.fakeCardDetail
 import tcg.pocket.dex.tierdecks.temporalPokemonTypePlaceholderDrawable
 import tcg.pocket.dex.ui.theme.ChipSize
@@ -30,21 +29,9 @@ fun PokemonMoves(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        Surface(
-            tonalElevation = 2.dp,
-            shadowElevation = 2.dp,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
-        ) {
-            Text(
-                text = "Moves",
-                style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = FontWeight.Bold,
-                    ),
-                modifier = Modifier.padding(4.dp),
-            )
-        }
+        PocketDexSectionHeader(
+            text = "Moves",
+        )
 
         Surface(
             tonalElevation = 2.dp,
@@ -63,9 +50,9 @@ fun PokemonMoves(
                                     contentDescription = energy.type,
                                     modifier = Modifier.size(ChipSize.Small),
                                     placeholder =
-                                        painterResource(
-                                            temporalPokemonTypePlaceholderDrawable,
-                                        ),
+                                    painterResource(
+                                        temporalPokemonTypePlaceholderDrawable,
+                                    ),
                                 )
                             }
                             Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/tcg/pocket/dex/allcards/PokemonMovesSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/PokemonMovesSection.kt
@@ -24,7 +24,7 @@ import tcg.pocket.dex.ui.theme.ChipSize
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable
-fun PokemonMoves(
+fun PokemonMovesSection(
     pokemonMoves: List<PokemonMove>,
     modifier: Modifier = Modifier,
 ) {
@@ -83,9 +83,9 @@ fun PokemonMoves(
 
 @Preview(showBackground = true)
 @Composable
-private fun PokemonMovesPreview() {
+private fun PokemonMovesSectionPreview() {
     TcgPocketDexTheme {
-        PokemonMoves(
+        PokemonMovesSection(
             pokemonMoves = fakeCardDetail.pokemonMoves,
         )
     }

--- a/app/src/main/java/tcg/pocket/dex/allcards/RelatedCardsSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/RelatedCardsSection.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.component.CardItem
 import tcg.pocket.dex.component.PocketDexSectionHeader
 import tcg.pocket.dex.tierdecks.fakeCardsData
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme

--- a/app/src/main/java/tcg/pocket/dex/allcards/RelatedCardsSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/RelatedCardsSection.kt
@@ -5,15 +5,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.component.PocketDexSectionHeader
 import tcg.pocket.dex.tierdecks.fakeCardsData
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
@@ -24,23 +21,10 @@ fun RelatedCardsSection(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        Surface(
-            tonalElevation = 2.dp,
-            shadowElevation = 2.dp,
-            modifier =
-                Modifier
-                    .fillMaxWidth(),
-            shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
-        ) {
-            Text(
-                text = "Related Cards",
-                style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = FontWeight.Bold,
-                    ),
-                modifier = Modifier.padding(4.dp),
-            )
-        }
+        PocketDexSectionHeader(
+            text = "Related Cards",
+        )
+
         Surface(
             tonalElevation = 2.dp,
             shadowElevation = 2.dp,

--- a/app/src/main/java/tcg/pocket/dex/allcards/RelatedDecksSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/RelatedDecksSection.kt
@@ -1,14 +1,10 @@
 package tcg.pocket.dex.allcards
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import tcg.pocket.dex.component.DeckItem
+import tcg.pocket.dex.component.DeckList
 import tcg.pocket.dex.component.PocketDexSectionHeader
 import tcg.pocket.dex.tierdecks.DeckItemState
 import tcg.pocket.dex.tierdecks.fakeDecksInformation
@@ -26,28 +22,7 @@ fun RelatedDecksSection(
             text = "Related Decks",
             modifier = modifier,
         )
-        Surface(
-            tonalElevation = 2.dp,
-            shadowElevation = 2.dp,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 4.dp),
-        ) {
-            Column {
-                deckItemsState.forEach { deckItemState ->
-                    DeckItem(
-                        information = deckItemState.content,
-                        expanded = deckItemState.expanded,
-                        onExpandedChange = { expanded ->
-                            onExpandDeck(deckItemState, expanded)
-                        },
-                        onCardClick = onDeckItemClick,
-                        modifier = Modifier.padding(bottom = 4.dp),
-                    )
-                }
-            }
-        }
+        DeckList(deckItemsState, onExpandDeck, onDeckItemClick)
     }
 }
 
@@ -56,7 +31,7 @@ fun RelatedDecksSection(
 private fun RelatedDecksContentPreview() {
     TcgPocketDexTheme {
         RelatedDecksSection(
-            deckItemsState = fakeDecksInformation.map(::DeckItemState),
+            deckItemsState = fakeDecksInformation.subList(0, 5).map(::DeckItemState),
             onDeckItemClick = { },
             onExpandDeck = { deckItemStata, _ -> },
         )

--- a/app/src/main/java/tcg/pocket/dex/allcards/RelatedDecksSection.kt
+++ b/app/src/main/java/tcg/pocket/dex/allcards/RelatedDecksSection.kt
@@ -8,8 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.component.DeckItem
 import tcg.pocket.dex.component.PocketDexSectionHeader
-import tcg.pocket.dex.tierdecks.DeckItem
 import tcg.pocket.dex.tierdecks.DeckItemState
 import tcg.pocket.dex.tierdecks.fakeDecksInformation
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme

--- a/app/src/main/java/tcg/pocket/dex/component/CardItem.kt
+++ b/app/src/main/java/tcg/pocket/dex/component/CardItem.kt
@@ -1,4 +1,4 @@
-package tcg.pocket.dex.allcards
+package tcg.pocket.dex.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import tcg.pocket.dex.allcards.CardData
 import tcg.pocket.dex.tierdecks.fakeCardsData
 import tcg.pocket.dex.tierdecks.temporalPokemonCardPlaceholderDrawable
 import tcg.pocket.dex.tierdecks.temporalPokemonCardRarityPlaceholderDrawable

--- a/app/src/main/java/tcg/pocket/dex/component/DeckItem.kt
+++ b/app/src/main/java/tcg/pocket/dex/component/DeckItem.kt
@@ -1,4 +1,4 @@
-package tcg.pocket.dex.tierdecks
+package tcg.pocket.dex.component
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
@@ -35,6 +35,12 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import tcg.pocket.dex.tierdecks.DeckInformation
+import tcg.pocket.dex.tierdecks.PokemonTypeChipData
+import tcg.pocket.dex.tierdecks.PokemonTypeChipGroup
+import tcg.pocket.dex.tierdecks.fakeDeckInformation
+import tcg.pocket.dex.tierdecks.fakeTierDeckDescription
+import tcg.pocket.dex.tierdecks.temporalPokemonPlaceholderDrawable
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable

--- a/app/src/main/java/tcg/pocket/dex/component/DeckItem.kt
+++ b/app/src/main/java/tcg/pocket/dex/component/DeckItem.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import tcg.pocket.dex.tierdecks.DeckInformation
 import tcg.pocket.dex.tierdecks.PokemonTypeChipData
-import tcg.pocket.dex.tierdecks.PokemonTypeChipGroup
 import tcg.pocket.dex.tierdecks.fakeDeckInformation
 import tcg.pocket.dex.tierdecks.fakeTierDeckDescription
 import tcg.pocket.dex.tierdecks.temporalPokemonPlaceholderDrawable

--- a/app/src/main/java/tcg/pocket/dex/component/DeckList.kt
+++ b/app/src/main/java/tcg/pocket/dex/component/DeckList.kt
@@ -1,0 +1,55 @@
+package tcg.pocket.dex.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.tierdecks.DeckItemState
+import tcg.pocket.dex.tierdecks.fakeDecksInformation
+import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
+
+@Composable
+fun DeckList(
+    deckItemsState: List<DeckItemState>,
+    onExpandDeck: (DeckItemState, Boolean) -> Unit,
+    onDeckItemClick: (String) -> Unit,
+) {
+    Surface(
+        tonalElevation = 2.dp,
+        shadowElevation = 2.dp,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(bottom = 4.dp),
+    ) {
+        Column {
+            deckItemsState.forEach { deckItemState ->
+                DeckItem(
+                    information = deckItemState.content,
+                    expanded = deckItemState.expanded,
+                    onExpandedChange = { expanded ->
+                        onExpandDeck(deckItemState, expanded)
+                    },
+                    onCardClick = onDeckItemClick,
+                    modifier = Modifier.padding(bottom = 4.dp),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DeckListPreview() {
+    TcgPocketDexTheme {
+        DeckList(
+            deckItemsState = fakeDecksInformation.map(::DeckItemState),
+            onDeckItemClick = { },
+            onExpandDeck = { deckItemStata, _ -> },
+        )
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/component/PokemonTypeChip.kt
+++ b/app/src/main/java/tcg/pocket/dex/component/PokemonTypeChip.kt
@@ -1,4 +1,4 @@
-package tcg.pocket.dex.tierdecks
+package tcg.pocket.dex.component
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,6 +18,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import tcg.pocket.dex.tierdecks.PokemonTypeChipData
+import tcg.pocket.dex.tierdecks.fakeFirePokemonTypeChipData
+import tcg.pocket.dex.tierdecks.temporalPokemonPlaceholderDrawable
 import tcg.pocket.dex.ui.theme.ChipSize
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 

--- a/app/src/main/java/tcg/pocket/dex/component/PokemonTypeChipGroup.kt
+++ b/app/src/main/java/tcg/pocket/dex/component/PokemonTypeChipGroup.kt
@@ -1,4 +1,4 @@
-package tcg.pocket.dex.tierdecks
+package tcg.pocket.dex.component
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -7,6 +7,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import tcg.pocket.dex.tierdecks.PokemonTypeChipData
+import tcg.pocket.dex.tierdecks.fakePokemonTypeChipDataset
 import tcg.pocket.dex.ui.theme.ChipSize
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/TierDecksScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/TierDecksScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import tcg.pocket.dex.component.DeckItem
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable

--- a/app/src/main/java/tcg/pocket/dex/tierdecks/TierDecksScreen.kt
+++ b/app/src/main/java/tcg/pocket/dex/tierdecks/TierDecksScreen.kt
@@ -3,12 +3,11 @@ package tcg.pocket.dex.tierdecks
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import tcg.pocket.dex.component.DeckItem
+import tcg.pocket.dex.component.DeckList
 import tcg.pocket.dex.ui.theme.TcgPocketDexTheme
 
 @Composable
@@ -24,16 +23,11 @@ fun TierDecksScreen(
                 .fillMaxWidth()
                 .padding(8.dp),
     ) {
-        items(
-            items = deckItemsState,
-            key = { deckItem -> deckItem.content.simple.deckId },
-        ) { deckItemState ->
-
-            DeckItem(
-                information = deckItemState.content,
-                expanded = deckItemState.expanded,
-                onExpandedChange = { expanded -> onExpandDeck(deckItemState, expanded) },
-                onCardClick = onDeckItemClick,
+        item {
+            DeckList(
+                deckItemsState = deckItemsState,
+                onExpandDeck = onExpandDeck,
+                onDeckItemClick = onDeckItemClick,
             )
         }
     }


### PR DESCRIPTION
## Work Video
NO

## Work Details
* Extracted Reusable Composables
* Refactored & Modularized Components
  * CardDetailHeader: Separated the header section from CardDetailScreen.
  * PokemonMoves: Extracted move details into a separate composable.
  * CardAttribute: Displays rarity, type, weakness, HP, retreat cost, and stage.
  * RelatedCardsSection: Now reuses CardItem to ensure UI consistency.
  * RelatedDecksSection: Extracted deck-related content, utilizing PocketDexSectionHeader.
  * PocketDexSectionHeader: Created a common section header component for uniform section titles.
* File Organization

## PR Points
NO

## 🚀 Next Feature
* use viewmodel
