### PR TITLE
[Feature] 승률 및 사용률 계산 기능 구현

### DIFF
--- a/app/src/main/java/tcg/pocket/dex/CalculatedDeck.kt
+++ b/app/src/main/java/tcg/pocket/dex/CalculatedDeck.kt
@@ -1,0 +1,25 @@
+package tcg.pocket.dex
+
+/**
+ * Represents a deck with calculated win rate and usage share statistics.
+ *
+ * This model is the final output of deck statistics calculation, providing
+ * formatted percentage strings ready for UI display.
+ *
+ * @property deckId Unique identifier for the deck
+ * @property deckName Human-readable deck name (e.g., "Pikachu + Mewtwo")
+ * @property winRate Formatted win rate percentage (e.g., "50.5%")
+ * @property usageShare Formatted usage share percentage representing how often this deck appears (e.g., "25.0%")
+ * @property appearances Number of times this deck appeared in tournament data
+ */
+data class CalculatedDeck(
+    val deckId: String,
+    val deckName: String,
+    val winRate: String,
+    val usageShare: String,
+    val appearances: Int,
+) {
+    init {
+        require(appearances >= 0) { "Appearances must be non-negative, but was $appearances" }
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/DeckStats.kt
+++ b/app/src/main/java/tcg/pocket/dex/DeckStats.kt
@@ -1,13 +1,16 @@
 package tcg.pocket.dex
 
 /**
- * Aggregated statistics for a deck across multiple tournament standings.
+ * Represents aggregated statistics for a deck across multiple tournament matches.
  *
- * @property deckId Unique identifier generated from sorted Pokemon composition
+ * This model stores raw win/loss counts and calculates win rate on demand.
+ * Used as an intermediate representation before converting to [CalculatedDeck] for display.
+ *
+ * @property deckId Unique identifier for the deck
  * @property deckName Human-readable deck name (e.g., "Pikachu + Mewtwo")
- * @property count Number of times this deck appeared in standings
- * @property totalWins Sum of all wins across all standings for this deck
- * @property totalLosses Sum of all losses across all standings for this deck
+ * @property count Number of times this deck appeared in tournament data
+ * @property totalWins Total number of wins across all appearances
+ * @property totalLosses Total number of losses across all appearances
  */
 data class DeckStats(
     val deckId: String,
@@ -16,15 +19,15 @@ data class DeckStats(
     val totalWins: Int,
     val totalLosses: Int,
 ) {
-    init {
-        require(count >= 0) { "count must be non-negative, but was $count" }
-        require(totalWins >= 0) { "totalWins must be non-negative, but was $totalWins" }
-        require(totalLosses >= 0) { "totalLosses must be non-negative, but was $totalLosses" }
-    }
-
     /**
-     * Calculate win rate as a decimal between 0.0 and 1.0.
-     * Returns 0.0 if there are no games (both wins and losses are 0).
+     * Calculated win rate as a decimal value (0.0 to 1.0).
+     *
+     * Returns 0.0 if no games have been played (totalWins + totalLosses = 0).
+     *
+     * Example:
+     * - 10 wins, 10 losses → 0.5 (50%)
+     * - 30 wins, 10 losses → 0.75 (75%)
+     * - 0 wins, 0 losses → 0.0 (no data)
      */
     val winRate: Double
         get() {
@@ -35,4 +38,10 @@ data class DeckStats(
                 0.0
             }
         }
+
+    init {
+        require(count >= 0) { "Count must be non-negative, but was $count" }
+        require(totalWins >= 0) { "Total wins must be non-negative, but was $totalWins" }
+        require(totalLosses >= 0) { "Total losses must be non-negative, but was $totalLosses" }
+    }
 }

--- a/app/src/main/java/tcg/pocket/dex/DeckStats.kt
+++ b/app/src/main/java/tcg/pocket/dex/DeckStats.kt
@@ -40,8 +40,8 @@ data class DeckStats(
         }
 
     init {
-        require(count >= 0) { "Count must be non-negative, but was $count" }
-        require(totalWins >= 0) { "Total wins must be non-negative, but was $totalWins" }
-        require(totalLosses >= 0) { "Total losses must be non-negative, but was $totalLosses" }
+        require(count >= 0) { "count must be non-negative, but was $count" }
+        require(totalWins >= 0) { "totalWins must be non-negative, but was $totalWins" }
+        require(totalLosses >= 0) { "totalLosses must be non-negative, but was $totalLosses" }
     }
 }

--- a/app/src/main/java/tcg/pocket/dex/DeckStatsCalculator.kt
+++ b/app/src/main/java/tcg/pocket/dex/DeckStatsCalculator.kt
@@ -1,0 +1,63 @@
+package tcg.pocket.dex
+
+/**
+ * Converts a map of [DeckStats] into a sorted list of [CalculatedDeck] with formatted percentages.
+ *
+ * This function performs the final calculation layer that:
+ * - Converts win rates from decimals (0.0-1.0) to formatted percentages (0.0%-100.0%)
+ * - Calculates usage share based on total deck appearances
+ * - Sorts results by usage share (descending), then win rate (descending)
+ *
+ * @receiver Map of deck IDs to their corresponding [DeckStats]
+ * @return Sorted list of [CalculatedDeck] ready for UI display. Returns empty list if input is empty.
+ *
+ * Example:
+ * ```
+ * val deckStatsMap = mapOf(
+ *     "pikachu-mewtwo" to DeckStats("pikachu-mewtwo", "Pikachu + Mewtwo", 100, 55, 45),
+ *     "charizard-moltres" to DeckStats("charizard-moltres", "Charizard + Moltres", 50, 30, 20)
+ * )
+ * val calculated = deckStatsMap.toCalculatedDecks()
+ * // Returns list sorted by usage share, then win rate
+ * ```
+ */
+fun Map<String, DeckStats>.toCalculatedDecks(): List<CalculatedDeck> {
+    // Handle empty input
+    if (isEmpty()) return emptyList()
+
+    // Calculate total number of deck appearances across all decks
+    val totalDecks = values.sumOf { it.count }
+
+    // Handle edge case where total is zero (shouldn't happen in practice)
+    if (totalDecks == 0) return emptyList()
+
+    // Transform each DeckStats into a CalculatedDeck with formatted percentages
+    return values.map { deckStats ->
+        // Convert win rate from decimal (0.0-1.0) to percentage (0.0%-100.0%)
+        val winRatePercentage = deckStats.winRate * 100.0
+
+        // Calculate usage share as percentage of total decks
+        val usageSharePercentage = (deckStats.count.toDouble() / totalDecks) * 100.0
+
+        CalculatedDeck(
+            deckId = deckStats.deckId,
+            deckName = deckStats.deckName,
+            winRate = formatPercentage(winRatePercentage),
+            usageShare = formatPercentage(usageSharePercentage),
+            appearances = deckStats.count,
+        )
+    }.sortedWith(
+        // Primary sort: usage share descending (most popular first)
+        // Secondary sort: win rate descending (highest win rate first)
+        compareByDescending<CalculatedDeck> { it.usageShare.removeSuffix("%").toDouble() }
+            .thenByDescending { it.winRate.removeSuffix("%").toDouble() },
+    )
+}
+
+/**
+ * Formats a percentage value to one decimal place with % suffix.
+ *
+ * @param value The percentage value to format (e.g., 50.0, 33.333)
+ * @return Formatted percentage string (e.g., "50.0%", "33.3%")
+ */
+private fun formatPercentage(value: Double): String = "%.1f%%".format(value)

--- a/app/src/test/java/tcg/pocket/dex/CalculatedDeckTest.kt
+++ b/app/src/test/java/tcg/pocket/dex/CalculatedDeckTest.kt
@@ -1,0 +1,429 @@
+package tcg.pocket.dex
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+
+class CalculatedDeckTest : BehaviorSpec({
+    Given("Valid CalculatedDeck parameters") {
+        val deckId = "pikachu-mewtwo-v1"
+        val deckName = "Pikachu + Mewtwo"
+        val winRate = "50.5%"
+        val usageShare = "25.0%"
+        val appearances = 100
+
+        When("Creating a CalculatedDeck with all valid fields") {
+            val deck =
+                CalculatedDeck(
+                    deckId = deckId,
+                    deckName = deckName,
+                    winRate = winRate,
+                    usageShare = usageShare,
+                    appearances = appearances,
+                )
+
+            Then("All properties should be accessible") {
+                deck.deckId shouldBe deckId
+                deck.deckName shouldBe deckName
+                deck.winRate shouldBe winRate
+                deck.usageShare shouldBe usageShare
+                deck.appearances shouldBe appearances
+            }
+
+            Then("Should be a valid object") {
+                shouldNotThrow<Exception> {
+                    deck.toString()
+                }
+            }
+        }
+
+        When("Creating a CalculatedDeck with zero appearances") {
+            Then("Should succeed without exception") {
+                shouldNotThrow<IllegalArgumentException> {
+                    CalculatedDeck(
+                        deckId = "test-deck",
+                        deckName = "Test Deck",
+                        winRate = "0.0%",
+                        usageShare = "0.0%",
+                        appearances = 0,
+                    )
+                }
+            }
+        }
+
+        When("Creating a CalculatedDeck with large appearance numbers") {
+            Then("Should handle 1000+ appearances correctly") {
+                val deck =
+                    CalculatedDeck(
+                        deckId = "popular-deck",
+                        deckName = "Popular Deck",
+                        winRate = "55.5%",
+                        usageShare = "40.0%",
+                        appearances = 1500,
+                    )
+
+                deck.appearances shouldBe 1500
+            }
+
+            Then("Should handle maximum Int value") {
+                val deck =
+                    CalculatedDeck(
+                        deckId = "max-deck",
+                        deckName = "Max Deck",
+                        winRate = "100.0%",
+                        usageShare = "100.0%",
+                        appearances = Int.MAX_VALUE,
+                    )
+
+                deck.appearances shouldBe Int.MAX_VALUE
+            }
+        }
+    }
+
+    Given("Invalid CalculatedDeck parameters") {
+        When("Appearances is negative") {
+            Then("Should throw IllegalArgumentException") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        CalculatedDeck(
+                            deckId = "invalid-deck",
+                            deckName = "Invalid Deck",
+                            winRate = "50.0%",
+                            usageShare = "25.0%",
+                            appearances = -1,
+                        )
+                    }
+
+                exception.message shouldContain "Appearances must be non-negative"
+                exception.message shouldContain "-1"
+            }
+        }
+
+        When("Appearances is negative with larger value") {
+            Then("Should throw with exact error message") {
+                val exception =
+                    shouldThrow<IllegalArgumentException> {
+                        CalculatedDeck(
+                            deckId = "test",
+                            deckName = "test",
+                            winRate = "0%",
+                            usageShare = "0%",
+                            appearances = -100,
+                        )
+                    }
+
+                exception.message shouldBe "Appearances must be non-negative, but was -100"
+            }
+        }
+
+        When("Appearances is at boundary: -1") {
+            Then("Should throw IllegalArgumentException") {
+                shouldThrow<IllegalArgumentException> {
+                    CalculatedDeck(
+                        deckId = "boundary",
+                        deckName = "Boundary",
+                        winRate = "0%",
+                        usageShare = "0%",
+                        appearances = -1,
+                    )
+                }
+            }
+        }
+
+        When("Appearances is at boundary: 0") {
+            Then("Should not throw exception") {
+                shouldNotThrow<IllegalArgumentException> {
+                    CalculatedDeck(
+                        deckId = "boundary",
+                        deckName = "Boundary",
+                        winRate = "0%",
+                        usageShare = "0%",
+                        appearances = 0,
+                    )
+                }
+            }
+        }
+    }
+
+    Given("CalculatedDeck data class behavior") {
+        val originalDeck =
+            CalculatedDeck(
+                deckId = "original",
+                deckName = "Original Deck",
+                winRate = "60.0%",
+                usageShare = "30.0%",
+                appearances = 200,
+            )
+
+        When("Using copy to create a new instance") {
+            val copiedDeck =
+                originalDeck.copy(
+                    deckName = "Modified Deck",
+                    appearances = 300,
+                )
+
+            Then("Should create a new instance with changed values") {
+                copiedDeck.deckId shouldBe "original"
+                copiedDeck.deckName shouldBe "Modified Deck"
+                copiedDeck.winRate shouldBe "60.0%"
+                copiedDeck.usageShare shouldBe "30.0%"
+                copiedDeck.appearances shouldBe 300
+            }
+
+            Then("Original should remain unchanged") {
+                originalDeck.deckName shouldBe "Original Deck"
+                originalDeck.appearances shouldBe 200
+            }
+
+            Then("Should be a different instance") {
+                copiedDeck shouldNotBe originalDeck
+            }
+        }
+
+        When("Comparing two identical decks") {
+            val deck1 =
+                CalculatedDeck(
+                    deckId = "same",
+                    deckName = "Same Deck",
+                    winRate = "50.0%",
+                    usageShare = "25.0%",
+                    appearances = 100,
+                )
+            val deck2 =
+                CalculatedDeck(
+                    deckId = "same",
+                    deckName = "Same Deck",
+                    winRate = "50.0%",
+                    usageShare = "25.0%",
+                    appearances = 100,
+                )
+
+            Then("Should be equal") {
+                deck1 shouldBe deck2
+            }
+
+            Then("Should have same hashCode") {
+                deck1.hashCode() shouldBe deck2.hashCode()
+            }
+        }
+
+        When("Comparing two different decks") {
+            val deck1 =
+                CalculatedDeck(
+                    deckId = "deck1",
+                    deckName = "Deck One",
+                    winRate = "50.0%",
+                    usageShare = "25.0%",
+                    appearances = 100,
+                )
+            val deck2 =
+                CalculatedDeck(
+                    deckId = "deck2",
+                    deckName = "Deck Two",
+                    winRate = "60.0%",
+                    usageShare = "30.0%",
+                    appearances = 150,
+                )
+
+            Then("Should not be equal") {
+                deck1 shouldNotBe deck2
+            }
+        }
+    }
+
+    Given("Edge cases for string fields") {
+        When("DeckId is an empty string") {
+            Then("Should succeed without exception") {
+                val deck =
+                    CalculatedDeck(
+                        deckId = "",
+                        deckName = "Empty ID Deck",
+                        winRate = "50.0%",
+                        usageShare = "25.0%",
+                        appearances = 50,
+                    )
+
+                deck.deckId shouldBe ""
+            }
+        }
+
+        When("DeckName is an empty string") {
+            Then("Should succeed without exception") {
+                val deck =
+                    CalculatedDeck(
+                        deckId = "empty-name",
+                        deckName = "",
+                        winRate = "50.0%",
+                        usageShare = "25.0%",
+                        appearances = 50,
+                    )
+
+                deck.deckName shouldBe ""
+            }
+        }
+
+        When("DeckName contains special characters") {
+            Then("Should handle special characters correctly") {
+                val specialName = "Pikachu⚡ + Mewtwo🌟 (Gen 1) - 50%+ Win Rate!"
+                val deck =
+                    CalculatedDeck(
+                        deckId = "special-chars",
+                        deckName = specialName,
+                        winRate = "52.5%",
+                        usageShare = "28.0%",
+                        appearances = 75,
+                    )
+
+                deck.deckName shouldBe specialName
+            }
+        }
+
+        When("DeckName is very long") {
+            Then("Should handle long strings correctly") {
+                val longName = "A".repeat(1000)
+                val deck =
+                    CalculatedDeck(
+                        deckId = "long-name",
+                        deckName = longName,
+                        winRate = "50.0%",
+                        usageShare = "25.0%",
+                        appearances = 100,
+                    )
+
+                deck.deckName shouldBe longName
+                deck.deckName.length shouldBe 1000
+            }
+        }
+
+        When("Percentage strings contain special formats") {
+            Then("Should accept any string format") {
+                val deck =
+                    CalculatedDeck(
+                        deckId = "special-format",
+                        deckName = "Special Format",
+                        winRate = "50.123456%",
+                        usageShare = "~25%",
+                        appearances = 100,
+                    )
+
+                deck.winRate shouldBe "50.123456%"
+                deck.usageShare shouldBe "~25%"
+            }
+        }
+
+        When("Percentage strings are empty") {
+            Then("Should accept empty strings") {
+                val deck =
+                    CalculatedDeck(
+                        deckId = "empty-percentages",
+                        deckName = "Empty Percentages",
+                        winRate = "",
+                        usageShare = "",
+                        appearances = 100,
+                    )
+
+                deck.winRate shouldBe ""
+                deck.usageShare shouldBe ""
+            }
+        }
+    }
+
+    Given("Data class toString and structural equality") {
+        When("Converting to string") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "test-deck",
+                    deckName = "Test Deck",
+                    winRate = "50.0%",
+                    usageShare = "25.0%",
+                    appearances = 100,
+                )
+
+            Then("Should contain all property values") {
+                val stringRepresentation = deck.toString()
+                stringRepresentation shouldContain "test-deck"
+                stringRepresentation shouldContain "Test Deck"
+                stringRepresentation shouldContain "50.0%"
+                stringRepresentation shouldContain "25.0%"
+                stringRepresentation shouldContain "100"
+            }
+        }
+
+        When("Using component functions") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "component-test",
+                    deckName = "Component Test",
+                    winRate = "55.0%",
+                    usageShare = "30.0%",
+                    appearances = 150,
+                )
+
+            Then("Should destructure correctly") {
+                val (deckId, deckName, winRate, usageShare, appearances) = deck
+
+                deckId shouldBe "component-test"
+                deckName shouldBe "Component Test"
+                winRate shouldBe "55.0%"
+                usageShare shouldBe "30.0%"
+                appearances shouldBe 150
+            }
+        }
+    }
+
+    Given("Real-world usage scenarios") {
+        When("Creating a deck with typical tournament data") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "pikachu-ex-mewtwo",
+                    deckName = "Pikachu ex + Mewtwo ex",
+                    winRate = "54.7%",
+                    usageShare = "32.1%",
+                    appearances = 456,
+                )
+
+            Then("Should represent valid tournament statistics") {
+                deck.deckId shouldBe "pikachu-ex-mewtwo"
+                deck.deckName shouldBe "Pikachu ex + Mewtwo ex"
+                deck.winRate shouldBe "54.7%"
+                deck.usageShare shouldBe "32.1%"
+                deck.appearances shouldBe 456
+            }
+        }
+
+        When("Creating a deck with perfect win rate") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "perfect-deck",
+                    deckName = "Perfect Deck",
+                    winRate = "100.0%",
+                    usageShare = "5.0%",
+                    appearances = 10,
+                )
+
+            Then("Should handle perfect win rate correctly") {
+                deck.winRate shouldBe "100.0%"
+                deck.appearances shouldBe 10
+            }
+        }
+
+        When("Creating a deck with zero win rate") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "zero-wins",
+                    deckName = "Zero Wins Deck",
+                    winRate = "0.0%",
+                    usageShare = "1.0%",
+                    appearances = 20,
+                )
+
+            Then("Should handle zero win rate correctly") {
+                deck.winRate shouldBe "0.0%"
+                deck.appearances shouldBe 20
+            }
+        }
+    }
+})

--- a/app/src/test/java/tcg/pocket/dex/DeckStatsCalculatorTest.kt
+++ b/app/src/test/java/tcg/pocket/dex/DeckStatsCalculatorTest.kt
@@ -1,0 +1,637 @@
+package tcg.pocket.dex
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+
+class DeckStatsCalculatorTest : BehaviorSpec({
+
+    // Helper function to create DeckStats easily
+    fun createDeckStats(
+        id: String,
+        name: String,
+        count: Int,
+        wins: Int,
+        losses: Int,
+    ): DeckStats =
+        DeckStats(
+            deckId = id,
+            deckName = name,
+            count = count,
+            totalWins = wins,
+            totalLosses = losses,
+        )
+
+    Given("win rate calculation") {
+        When("deck has 50% win rate (10 wins, 10 losses)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 10, 10, 10),
+                )
+
+            Then("win rate should be formatted as 50.0%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "50.0%"
+            }
+        }
+
+        When("deck has 75% win rate (30 wins, 10 losses)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 40, 30, 10),
+                )
+
+            Then("win rate should be formatted as 75.0%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "75.0%"
+            }
+        }
+
+        When("deck has 33.3% win rate (10 wins, 20 losses)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 30, 10, 20),
+                )
+
+            Then("win rate should be formatted as 33.3%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "33.3%"
+            }
+        }
+
+        When("deck has 100% win rate (20 wins, 0 losses)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 20, 20, 0),
+                )
+
+            Then("win rate should be formatted as 100.0%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "100.0%"
+            }
+        }
+
+        When("deck has 0% win rate (0 wins, 20 losses)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 20, 0, 20),
+                )
+
+            Then("win rate should be formatted as 0.0%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "0.0%"
+            }
+        }
+
+        When("deck has no games played (0 wins, 0 losses)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 10, 0, 0),
+                )
+
+            Then("win rate should be formatted as 0.0%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "0.0%"
+            }
+        }
+
+        When("deck has win rate requiring rounding (20 wins, 10 losses = 66.666%)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 30, 20, 10),
+                )
+
+            Then("win rate should be rounded to 66.7%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "66.7%"
+            }
+        }
+
+        When("deck has win rate requiring rounding down (10 wins, 21 losses = 32.258%)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 31, 10, 21),
+                )
+
+            Then("win rate should be rounded to 32.3%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "32.3%"
+            }
+        }
+    }
+
+    Given("usage share calculation") {
+        When("single deck with 100% usage") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 10, 5, 5),
+                )
+
+            Then("usage share should be 100.0%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].usageShare shouldBe "100.0%"
+                result[0].appearances shouldBe 10
+            }
+        }
+
+        When("two decks with equal usage (5 each, total 10)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 5, 3, 2),
+                    "deck2" to createDeckStats("deck2", "Deck 2", 5, 4, 1),
+                )
+
+            Then("each should have 50.0% usage share") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 2
+                result.forEach { deck ->
+                    deck.usageShare shouldBe "50.0%"
+                    deck.appearances shouldBe 5
+                }
+            }
+        }
+
+        When("deck with one-third usage (10 of 30)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 10, 5, 5),
+                    "deck2" to createDeckStats("deck2", "Deck 2", 20, 10, 10),
+                )
+
+            Then("usage shares should be 33.3% and 66.7%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 2
+                result[0].usageShare shouldBe "66.7%"
+                result[0].appearances shouldBe 20
+                result[1].usageShare shouldBe "33.3%"
+                result[1].appearances shouldBe 10
+            }
+        }
+
+        When("deck with very low usage (1 of 1000)") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 1, 1, 0),
+                    "deck2" to createDeckStats("deck2", "Deck 2", 999, 500, 499),
+                )
+
+            Then("usage shares should be 0.1% and 99.9%") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 2
+                result[0].usageShare shouldBe "99.9%"
+                result[1].usageShare shouldBe "0.1%"
+            }
+        }
+
+        When("multiple decks with different shares") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 50, 25, 25),
+                    "deck2" to createDeckStats("deck2", "Deck 2", 30, 15, 15),
+                    "deck3" to createDeckStats("deck3", "Deck 3", 20, 10, 10),
+                )
+
+            Then("usage shares should sum to 100% and be correctly calculated") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 3
+                result[0].usageShare shouldBe "50.0%"
+                result[0].appearances shouldBe 50
+                result[1].usageShare shouldBe "30.0%"
+                result[1].appearances shouldBe 30
+                result[2].usageShare shouldBe "20.0%"
+                result[2].appearances shouldBe 20
+            }
+        }
+    }
+
+    Given("percentage formatting") {
+        When("value requires one decimal place rounding") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 333, 167, 166),
+                    "deck2" to createDeckStats("deck2", "Deck 2", 667, 333, 334),
+                )
+
+            Then("all percentages should have exactly one decimal place") {
+                val result = deckStats.toCalculatedDecks()
+                result.forEach { deck ->
+                    deck.winRate shouldEndWith "%"
+                    deck.usageShare shouldEndWith "%"
+                    deck.winRate.count { it == '.' } shouldBe 1
+                    deck.usageShare.count { it == '.' } shouldBe 1
+                }
+            }
+        }
+
+        When("value is whole number") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 10, 5, 5),
+                )
+
+            Then("should still show .0 decimal") {
+                val result = deckStats.toCalculatedDecks()
+                result[0].winRate shouldBe "50.0%"
+                result[0].usageShare shouldBe "100.0%"
+            }
+        }
+
+        When("all percentages are calculated") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 10, 5, 5),
+                )
+
+            Then("all should include % symbol") {
+                val result = deckStats.toCalculatedDecks()
+                result[0].winRate shouldEndWith "%"
+                result[0].usageShare shouldEndWith "%"
+            }
+        }
+    }
+
+    Given("sorting behavior") {
+        When("decks have different usage shares") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Low Usage", 10, 5, 5),
+                    "deck2" to createDeckStats("deck2", "High Usage", 50, 25, 25),
+                    "deck3" to createDeckStats("deck3", "Medium Usage", 30, 15, 15),
+                )
+
+            Then("should sort by usage share descending") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 3
+                result[0].deckName shouldBe "High Usage"
+                result[0].usageShare shouldBe "55.6%"
+                result[1].deckName shouldBe "Medium Usage"
+                result[1].usageShare shouldBe "33.3%"
+                result[2].deckName shouldBe "Low Usage"
+                result[2].usageShare shouldBe "11.1%"
+            }
+        }
+
+        When("decks have same usage share but different win rates") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Low WR", 10, 3, 7),
+                    "deck2" to createDeckStats("deck2", "High WR", 10, 7, 3),
+                    "deck3" to createDeckStats("deck3", "Medium WR", 10, 5, 5),
+                )
+
+            Then("should sort by win rate descending as secondary sort") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 3
+                result[0].deckName shouldBe "High WR"
+                result[0].winRate shouldBe "70.0%"
+                result[1].deckName shouldBe "Medium WR"
+                result[1].winRate shouldBe "50.0%"
+                result[2].deckName shouldBe "Low WR"
+                result[2].winRate shouldBe "30.0%"
+            }
+        }
+
+        When("decks have different usage and win rates combined") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "High Usage Low WR", 50, 15, 35),
+                    "deck2" to createDeckStats("deck2", "Low Usage High WR", 10, 9, 1),
+                    "deck3" to createDeckStats("deck3", "Medium Usage Medium WR", 30, 15, 15),
+                )
+
+            Then("should prioritize usage share over win rate") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 3
+                result[0].deckName shouldBe "High Usage Low WR"
+                result[0].usageShare shouldBe "55.6%"
+                result[1].deckName shouldBe "Medium Usage Medium WR"
+                result[1].usageShare shouldBe "33.3%"
+                result[2].deckName shouldBe "Low Usage High WR"
+                result[2].usageShare shouldBe "11.1%"
+            }
+        }
+
+        When("all decks have same usage and win rate") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck A", 10, 5, 5),
+                    "deck2" to createDeckStats("deck2", "Deck B", 10, 5, 5),
+                    "deck3" to createDeckStats("deck3", "Deck C", 10, 5, 5),
+                )
+
+            Then("order should be stable") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 3
+                result.forEach { deck ->
+                    deck.usageShare shouldBe "33.3%"
+                    deck.winRate shouldBe "50.0%"
+                }
+            }
+        }
+
+        When("all decks have same win rate but different usage") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Usage 10", 10, 5, 5),
+                    "deck2" to createDeckStats("deck2", "Usage 50", 50, 25, 25),
+                    "deck3" to createDeckStats("deck3", "Usage 30", 30, 15, 15),
+                )
+
+            Then("should sort only by usage share descending") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 3
+                result.forEach { it.winRate shouldBe "50.0%" }
+                result[0].deckName shouldBe "Usage 50"
+                result[1].deckName shouldBe "Usage 30"
+                result[2].deckName shouldBe "Usage 10"
+            }
+        }
+    }
+
+    Given("edge cases") {
+        When("map is empty") {
+            val deckStats = emptyMap<String, DeckStats>()
+
+            Then("should return empty list") {
+                val result = deckStats.toCalculatedDecks()
+                result.shouldBeEmpty()
+            }
+        }
+
+        When("single deck in map") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Only Deck", 10, 7, 3),
+                )
+
+            Then("should return list with one properly calculated deck") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 1
+                result[0].deckName shouldBe "Only Deck"
+                result[0].winRate shouldBe "70.0%"
+                result[0].usageShare shouldBe "100.0%"
+                result[0].appearances shouldBe 10
+            }
+        }
+
+        When("deck has zero count but positive wins/losses") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 0, 5, 5),
+                    "deck2" to createDeckStats("deck2", "Deck 2", 10, 5, 5),
+                )
+
+            Then("should handle zero count gracefully") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 2
+                result[0].appearances shouldBe 10
+                result[1].appearances shouldBe 0
+            }
+        }
+
+        When("all decks have zero count") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Deck 1", 0, 0, 0),
+                    "deck2" to createDeckStats("deck2", "Deck 2", 0, 0, 0),
+                )
+
+            Then("should return empty list") {
+                val result = deckStats.toCalculatedDecks()
+                result.shouldBeEmpty()
+            }
+        }
+
+        When("large dataset with 100+ decks") {
+            val deckStats =
+                (1..100).associate { i ->
+                    "deck$i" to createDeckStats("deck$i", "Deck $i", i, i / 2, i / 2)
+                }
+
+            Then("should calculate and sort all decks correctly") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 100
+
+                // Verify descending order by usage share
+                val usageShares =
+                    result.map {
+                        it.usageShare.removeSuffix("%").toDouble()
+                    }
+                usageShares shouldBe usageShares.sortedDescending()
+
+                // Verify all have percentage format
+                result.forEach { deck ->
+                    deck.winRate shouldEndWith "%"
+                    deck.usageShare shouldEndWith "%"
+                }
+            }
+        }
+    }
+
+    Given("real-world tournament scenarios") {
+        When("realistic tournament meta with top decks") {
+            val deckStats =
+                mapOf(
+                    "mewtwo_gardevoir" to
+                        createDeckStats(
+                            "mewtwo_gardevoir",
+                            "Mewtwo + Gardevoir",
+                            120,
+                            75,
+                            45,
+                        ),
+                    "pikachu_ex" to
+                        createDeckStats(
+                            "pikachu_ex",
+                            "Pikachu EX",
+                            95,
+                            60,
+                            35,
+                        ),
+                    "charizard_moltres" to
+                        createDeckStats(
+                            "charizard_moltres",
+                            "Charizard + Moltres",
+                            85,
+                            48,
+                            37,
+                        ),
+                    "starmie_ex" to
+                        createDeckStats(
+                            "starmie_ex",
+                            "Starmie EX",
+                            50,
+                            32,
+                            18,
+                        ),
+                    "meowth_persian" to
+                        createDeckStats(
+                            "meowth_persian",
+                            "Meowth + Persian",
+                            30,
+                            15,
+                            15,
+                        ),
+                )
+
+            Then("should produce realistic meta snapshot") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 5
+
+                // Most popular deck first
+                result[0].deckName shouldBe "Mewtwo + Gardevoir"
+                result[0].usageShare shouldBe "31.6%"
+                result[0].winRate shouldBe "62.5%"
+
+                // Verify total usage sums to approximately 100% (accounting for rounding)
+                val totalUsage =
+                    result.sumOf {
+                        it.usageShare.removeSuffix("%").toDouble()
+                    }
+                totalUsage shouldBe (100.0 plusOrMinus 0.5)
+
+                // Verify sorted by usage descending
+                result[0].appearances shouldBe 120
+                result[1].appearances shouldBe 95
+                result[2].appearances shouldBe 85
+                result[3].appearances shouldBe 50
+                result[4].appearances shouldBe 30
+            }
+        }
+
+        When("meta dominated by one deck") {
+            val deckStats =
+                mapOf(
+                    "dominant" to createDeckStats("dominant", "Meta King", 200, 140, 60),
+                    "tier2_1" to createDeckStats("tier2_1", "Tier 2 Deck A", 30, 15, 15),
+                    "tier2_2" to createDeckStats("tier2_2", "Tier 2 Deck B", 20, 10, 10),
+                )
+
+            Then("should show clear dominance in usage and win rate") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 3
+
+                result[0].deckName shouldBe "Meta King"
+                result[0].usageShare shouldBe "80.0%"
+                result[0].winRate shouldBe "70.0%"
+
+                result[1].usageShare shouldBe "12.0%"
+                result[2].usageShare shouldBe "8.0%"
+            }
+        }
+
+        When("balanced meta with many viable decks") {
+            val deckStats =
+                (1..10).associate { i ->
+                    "deck$i" to
+                        createDeckStats(
+                            "deck$i",
+                            "Viable Deck $i",
+                            count = 50,
+                            wins = 25 + (i % 5) - 2, // Win rates vary 46%-54%
+                            losses = 25 - (i % 5) + 2,
+                        )
+                }
+
+            Then("should show balanced usage shares") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 10
+
+                // All should have same usage share
+                result.forEach { deck ->
+                    deck.usageShare shouldBe "10.0%"
+                    deck.appearances shouldBe 50
+                }
+
+                // Should be sorted by win rate descending
+                val winRates =
+                    result.map {
+                        it.winRate.removeSuffix("%").toDouble()
+                    }
+                winRates shouldBe winRates.sortedDescending()
+            }
+        }
+
+        When("underdog deck with high win rate but low usage") {
+            val deckStats =
+                mapOf(
+                    "popular_mediocre" to
+                        createDeckStats(
+                            "popular_mediocre",
+                            "Popular Mediocre",
+                            100,
+                            50,
+                            50,
+                        ),
+                    "underdog_strong" to
+                        createDeckStats(
+                            "underdog_strong",
+                            "Hidden Gem",
+                            10,
+                            9,
+                            1,
+                        ),
+                )
+
+            Then("should prioritize usage in sorting despite higher win rate") {
+                val result = deckStats.toCalculatedDecks()
+                result shouldHaveSize 2
+
+                // Higher usage comes first despite lower win rate
+                result[0].deckName shouldBe "Popular Mediocre"
+                result[0].usageShare shouldBe "90.9%"
+                result[0].winRate shouldBe "50.0%"
+
+                result[1].deckName shouldBe "Hidden Gem"
+                result[1].usageShare shouldBe "9.1%"
+                result[1].winRate shouldBe "90.0%"
+            }
+        }
+    }
+
+    Given("data integrity verification") {
+        When("calculating deck statistics") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Test Deck 1", 25, 15, 10),
+                    "deck2" to createDeckStats("deck2", "Test Deck 2", 75, 40, 35),
+                )
+
+            Then("deck IDs and names should be preserved") {
+                val result = deckStats.toCalculatedDecks()
+                result[0].deckId shouldBe "deck2"
+                result[0].deckName shouldBe "Test Deck 2"
+                result[1].deckId shouldBe "deck1"
+                result[1].deckName shouldBe "Test Deck 1"
+            }
+        }
+
+        When("converting to CalculatedDeck") {
+            val deckStats =
+                mapOf(
+                    "deck1" to createDeckStats("deck1", "Test", 50, 30, 20),
+                )
+
+            Then("all fields should be properly populated") {
+                val result = deckStats.toCalculatedDecks()
+                result[0].deckId shouldBe "deck1"
+                result[0].deckName shouldBe "Test"
+                result[0].appearances shouldBe 50
+                result[0].winRate shouldBe "60.0%"
+                result[0].usageShare shouldBe "100.0%"
+            }
+        }
+    }
+})

--- a/app/src/test/java/tcg/pocket/dex/DeckStatsCalculatorTest.kt
+++ b/app/src/test/java/tcg/pocket/dex/DeckStatsCalculatorTest.kt
@@ -540,7 +540,8 @@ class DeckStatsCalculatorTest : BehaviorSpec({
                             "deck$i",
                             "Viable Deck $i",
                             count = 50,
-                            wins = 25 + (i % 5) - 2, // Win rates vary 46%-54%
+                            // Win rates vary 46%-54%
+                            wins = 25 + (i % 5) - 2,
                             losses = 25 - (i % 5) + 2,
                         )
                 }


### PR DESCRIPTION
## 요약

DeckStats를 백분율로 변환하고 정렬하여 화면 표시용 최종 계산 레이어를 구현했습니다.

## 변경 사항

- `CalculatedDeck` 도메인 모델 생성 (승률, 사용률, 등장 횟수를 포함한 최종 계산 결과)
- `DeckStatsCalculator` 확장 함수 구현 (Map<String, DeckStats>를 List<CalculatedDeck>으로 변환)
- 승률 계산: `totalWins / (totalWins + totalLosses)` → 백분율 형식 ("50.5%")
- 사용률 계산: `count / totalDecksAnalyzed` → 백분율 형식 ("25.0%")
- 정렬 로직: 사용률 내림차순 (1차), 승률 내림차순 (2차)
- 0으로 나누기 예외 처리 (게임 기록이 없는 덱)

## 구현 세부사항

### CalculatedDeck 도메인 모델
- 불변 데이터 클래스로 구현
- 속성: `deckId`, `deckName`, `winRate`, `usageShare`, `appearances`
- 검증: `appearances >= 0` (init 블록에서 검증)
- KDoc 문서화 완료

### DeckStatsCalculator 확장 함수
- `Map<String, DeckStats>.toCalculatedDecks()` 확장 함수
- 승률: DeckStats.winRate (0.0-1.0)를 백분율로 변환
- 사용률: 개별 덱 등장 횟수를 전체 덱 수로 나눈 백분율
- 형식화: `"%.1f%%".format(value)` (소수점 1자리)
- 엣지 케이스 처리:
  - 빈 맵 → 빈 리스트 반환
  - totalDecks = 0 → 빈 리스트 반환 (0으로 나누기 방지)

### 정렬 로직
```kotlin
compareByDescending<CalculatedDeck> { it.usageShare.removeSuffix("%").toDouble() }
    .thenByDescending { it.winRate.removeSuffix("%").toDouble() }
```

## 테스트

- [x] 유닛 테스트 작성 완료 (58개 테스트 케이스)
  - `CalculatedDeckTest.kt`: 26개 테스트 (모델 검증, 불변성, 엣지 케이스)
  - `DeckStatsCalculatorTest.kt`: 32개 테스트 (계산 로직, 정렬, 실제 시나리오)
- [x] 테스트 통과 확인 (195개 테스트 모두 성공)
- [x] 린트 검사 통과 (ktlint)
- [x] 빌드 성공 확인 (./gradlew build)

### 테스트 커버리지 세부사항
- 승률 계산: 50%, 75%, 33.3%, 100%, 0% 등 다양한 시나리오
- 사용률 계산: 단일 덱, 균등 분할, 불균등 분할, 저사용률
- 백분율 형식화: 반올림, 소수점 표시, % 기호 포함
- 정렬: 1차/2차 정렬, 동점 처리
- 엣지 케이스: 빈 입력, 대규모 데이터셋, 0 카운트
- 실제 토너먼트 시나리오: 메타 지배 덱, 균형잡힌 메타, 언더독 덱

## 코드 품질

- KDoc 문서화: 모든 공개 클래스와 함수에 대한 상세한 설명
- 기존 패턴 준수: Card.kt, DeckStats.kt의 패턴을 따름
- Kotlin 컨벤션: camelCase, 불변 데이터 클래스, init 블록 검증
- 테스트 패턴: Kotest BehaviorSpec (Given-When-Then 구조)

## 의존성

- Issue #26의 DeckStats 모델 필요 (이미 dev 브랜치에 병합됨)
- 모든 테스트에서 DeckStats를 포함하여 컴파일 및 실행 확인

## 관련 이슈

Closes #27