### PR TITLE
feat(repo): add tournament statistics repository layer

### DIFF
--- a/.claude/plan/mvp-progress.md
+++ b/.claude/plan/mvp-progress.md
@@ -75,22 +75,27 @@
   - 위치: `app/src/main/java/tcg/pocket/dex/repo/decks/`
   - 인터페이스: `DecksRepo` 구현
 
-- [ ] `RemoteTournamentDataSource` 연결
+- [x] `RemoteTournamentDataSource` 연결 ✅ (Issues #24-25 완료)
   - 위치: `app/src/main/java/tcg/pocket/dex/datasource/`
   - API: Limitless TCG 토너먼트 데이터
 
-- [ ] 덱 통계 집계 로직 구현 (README 3-4단계)
+- [x] 덱 통계 집계 로직 구현 (README 3-4단계) ✅ (Issues #26-27 완료)
   - 토너먼트 결과 → 덱별 집계
   - 승률 계산 (승/전체)
   - 점유율 계산 (덱 사용 횟수/전체)
   - 참고: `DeckStatsAggregatorTest.kt`
 
+- [x] `TournamentStatsRepo` 생성 ✅ (Issue #28 완료)
+  - 위치: `app/src/main/java/tcg/pocket/dex/repo/tournamentstats/`
+  - 전체 파이프라인 오케스트레이션 레이어
+  - `getDeckStatistics()` → `List<CalculatedDeck>` 반환
+
 - [ ] `TierDecksViewModel` 수정
   - `FakeDecksRepo` → `DefaultDecksRepo` 교체
   - 에러 처리 추가
 
-- [ ] 테스트 작성
-  - `DefaultDecksRepoTest.kt`
+- [x] 테스트 작성 ✅ (Issue #28 완료)
+  - `DefaultTournamentStatsRepoTest.kt` (16 테스트)
   - API 연동 검증
 
 **완료 조건**:
@@ -434,7 +439,8 @@
 ## ✅ 체크리스트
 
 ### Phase 1: 핵심 기능
-- [ ] DefaultDecksRepo 구현 완료
+- [x] TournamentStatsRepo 구현 완료 ✅ (Issue #28 - 2025-12-10)
+- [ ] DefaultDecksRepo 구현 완료 (TournamentStatsRepo 사용)
 - [ ] 티어 덱 실제 데이터 표시
 - [ ] DeckDetailScreen UI 완성
 - [ ] 모든 ViewModel 에러 처리

--- a/app/src/main/java/tcg/pocket/dex/repo/tournamentstats/DefaultTournamentStatsRepo.kt
+++ b/app/src/main/java/tcg/pocket/dex/repo/tournamentstats/DefaultTournamentStatsRepo.kt
@@ -1,0 +1,17 @@
+package tcg.pocket.dex.repo.tournamentstats
+
+import tcg.pocket.dex.CalculatedDeck
+import tcg.pocket.dex.DeckStatsAggregator
+import tcg.pocket.dex.datasource.RemoteTournamentDataSource
+import tcg.pocket.dex.toCalculatedDecks
+
+class DefaultTournamentStatsRepo(
+    private val remoteTournamentDataSource: RemoteTournamentDataSource,
+) : TournamentStatsRepo {
+    override suspend fun getDeckStatistics(): List<CalculatedDeck> {
+        val tournamentIds = remoteTournamentDataSource.getQualifyingTournamentIds()
+        val standings = remoteTournamentDataSource.getTop8Standings(tournamentIds.map { it.id })
+        val deckStats = DeckStatsAggregator.aggregate(standings)
+        return deckStats.toCalculatedDecks()
+    }
+}

--- a/app/src/main/java/tcg/pocket/dex/repo/tournamentstats/TournamentStatsRepo.kt
+++ b/app/src/main/java/tcg/pocket/dex/repo/tournamentstats/TournamentStatsRepo.kt
@@ -1,0 +1,7 @@
+package tcg.pocket.dex.repo.tournamentstats
+
+import tcg.pocket.dex.CalculatedDeck
+
+interface TournamentStatsRepo {
+    suspend fun getDeckStatistics(): List<CalculatedDeck>
+}

--- a/app/src/test/java/tcg/pocket/dex/repo/tournamentstats/DefaultTournamentStatsRepoTest.kt
+++ b/app/src/test/java/tcg/pocket/dex/repo/tournamentstats/DefaultTournamentStatsRepoTest.kt
@@ -1,0 +1,569 @@
+package tcg.pocket.dex.repo.tournamentstats
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import tcg.pocket.dex.datasource.RemoteTournamentDataSource
+import tcg.pocket.dex.remote.response.Standing
+import tcg.pocket.dex.remote.response.TournamentId
+
+class DefaultTournamentStatsRepoTest : BehaviorSpec({
+    val mockDataSource = mockk<RemoteTournamentDataSource>()
+    val repo = DefaultTournamentStatsRepo(mockDataSource)
+
+    beforeEach {
+        clearMocks(mockDataSource)
+    }
+
+    fun createStanding(
+        placing: Int = 1,
+        playerName: String = "Player",
+        deckPokemon: List<String> = listOf("Pikachu"),
+        wins: Int = 5,
+        losses: Int = 2,
+        ties: Int = 0,
+        country: String? = null,
+        region: String? = null,
+    ): Standing =
+        Standing(
+            placing = placing,
+            playerName = playerName,
+            country = country,
+            region = region,
+            deckPokemon = deckPokemon,
+            wins = wins,
+            losses = losses,
+            ties = ties,
+        )
+
+    fun createTournamentId(id: String = "tournament-1"): TournamentId = TournamentId(id)
+
+    Given("정상적인 토너먼트 ID와 순위 데이터") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("올바른 승률과 사용률을 가진 계산된 덱을 반환해야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                        createTournamentId("t2"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1", "t2")) } returns
+                    listOf(
+                        createStanding(
+                            placing = 1,
+                            playerName = "Player1",
+                            deckPokemon = listOf("Pikachu", "Mewtwo"),
+                            wins = 6,
+                            losses = 1,
+                        ),
+                        createStanding(
+                            placing = 2,
+                            playerName = "Player2",
+                            deckPokemon = listOf("Mewtwo", "Pikachu"),
+                            wins = 5,
+                            losses = 2,
+                        ),
+                        createStanding(
+                            placing = 3,
+                            playerName = "Player3",
+                            deckPokemon = listOf("Charizard"),
+                            wins = 4,
+                            losses = 3,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 2
+                result[0].deckName shouldBe "Mewtwo + Pikachu"
+                result[0].appearances shouldBe 2
+                result[0].usageShare shouldBe "66.7%"
+                result[0].winRate shouldBe "78.6%"
+                result[1].deckName shouldBe "Charizard"
+                result[1].appearances shouldBe 1
+                result[1].usageShare shouldBe "33.3%"
+                result[1].winRate shouldBe "57.1%"
+            }
+        }
+    }
+
+    Given("빈 토너먼트 리스트") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("빈 리스트를 반환해야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns emptyList()
+                coEvery { mockDataSource.getTop8Standings(emptyList()) } returns emptyList()
+
+                val result = repo.getDeckStatistics()
+
+                result.shouldBeEmpty()
+                coVerify(exactly = 1) { mockDataSource.getQualifyingTournamentIds() }
+                coVerify(exactly = 1) { mockDataSource.getTop8Standings(emptyList()) }
+            }
+        }
+    }
+
+    Given("토너먼트 ID는 있지만 순위 데이터가 없는 경우") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("빈 리스트를 반환해야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                        createTournamentId("t2"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1", "t2")) } returns emptyList()
+
+                val result = repo.getDeckStatistics()
+
+                result.shouldBeEmpty()
+                coVerify(exactly = 1) { mockDataSource.getQualifyingTournamentIds() }
+                coVerify(exactly = 1) { mockDataSource.getTop8Standings(listOf("t1", "t2")) }
+            }
+        }
+    }
+
+    Given("모든 순위가 동일한 덱을 사용하는 경우") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("100% 사용률을 가진 단일 덱을 반환해야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(
+                            placing = 1,
+                            playerName = "Player1",
+                            deckPokemon = listOf("Pikachu"),
+                            wins = 6,
+                            losses = 1,
+                        ),
+                        createStanding(
+                            placing = 2,
+                            playerName = "Player2",
+                            deckPokemon = listOf("Pikachu"),
+                            wins = 5,
+                            losses = 2,
+                        ),
+                        createStanding(
+                            placing = 3,
+                            playerName = "Player3",
+                            deckPokemon = listOf("Pikachu"),
+                            wins = 4,
+                            losses = 3,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 1
+                result[0].deckName shouldBe "Pikachu"
+                result[0].appearances shouldBe 3
+                result[0].usageShare shouldBe "100.0%"
+                result[0].winRate shouldBe "71.4%"
+            }
+        }
+    }
+
+    Given("여러 다른 덱이 있는 순위 데이터") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("사용률 순으로 정렬된 여러 덱을 반환해야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(
+                            placing = 1,
+                            playerName = "Player1",
+                            deckPokemon = listOf("Pikachu", "Mewtwo"),
+                            wins = 6,
+                            losses = 1,
+                        ),
+                        createStanding(
+                            placing = 2,
+                            playerName = "Player2",
+                            deckPokemon = listOf("Mewtwo", "Pikachu"),
+                            wins = 5,
+                            losses = 2,
+                        ),
+                        createStanding(
+                            placing = 3,
+                            playerName = "Player3",
+                            deckPokemon = listOf("Charizard"),
+                            wins = 4,
+                            losses = 3,
+                        ),
+                        createStanding(
+                            placing = 4,
+                            playerName = "Player4",
+                            deckPokemon = listOf("Pikachu", "Mewtwo"),
+                            wins = 4,
+                            losses = 3,
+                        ),
+                        createStanding(
+                            placing = 5,
+                            playerName = "Player5",
+                            deckPokemon = listOf("Charizard"),
+                            wins = 3,
+                            losses = 4,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 2
+                result[0].deckName shouldBe "Mewtwo + Pikachu"
+                result[0].appearances shouldBe 3
+                result[0].usageShare shouldBe "60.0%"
+                result[1].deckName shouldBe "Charizard"
+                result[1].appearances shouldBe 2
+                result[1].usageShare shouldBe "40.0%"
+            }
+        }
+    }
+
+    Given("데이터소스 메서드 호출 검증") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("올바른 파라미터로 데이터소스 메서드를 호출해야 한다") {
+                val tournamentIds =
+                    listOf(
+                        createTournamentId("t1"),
+                        createTournamentId("t2"),
+                        createTournamentId("t3"),
+                    )
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns tournamentIds
+                coEvery { mockDataSource.getTop8Standings(listOf("t1", "t2", "t3")) } returns
+                    listOf(
+                        createStanding(
+                            deckPokemon = listOf("Pikachu"),
+                            wins = 5,
+                            losses = 2,
+                        ),
+                    )
+
+                repo.getDeckStatistics()
+
+                coVerify(exactly = 1) { mockDataSource.getQualifyingTournamentIds() }
+                coVerify(exactly = 1) { mockDataSource.getTop8Standings(listOf("t1", "t2", "t3")) }
+            }
+        }
+    }
+
+    Given("덱 ID와 이름 매핑 검증") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("덱 ID와 이름이 올바르게 매핑되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(
+                            deckPokemon = listOf("Pikachu", "Raichu"),
+                            wins = 5,
+                            losses = 2,
+                        ),
+                        createStanding(
+                            deckPokemon = listOf("Raichu", "Pikachu"),
+                            wins = 4,
+                            losses = 3,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 1
+                result[0].deckId shouldBe "Pikachu|Raichu"
+                result[0].deckName shouldBe "Pikachu + Raichu"
+            }
+        }
+    }
+
+    Given("승률 계산 검증") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("승률이 올바르게 계산되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(
+                            deckPokemon = listOf("Pikachu"),
+                            wins = 10,
+                            losses = 5,
+                        ),
+                        createStanding(
+                            deckPokemon = listOf("Pikachu"),
+                            wins = 5,
+                            losses = 5,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 1
+                result[0].winRate shouldBe "60.0%"
+            }
+        }
+    }
+
+    Given("사용률 계산 검증") {
+        When("여러 덱이 있을 때") {
+            Then("각 덱의 사용률이 올바르게 계산되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(deckPokemon = listOf("Pikachu"), wins = 5, losses = 2),
+                        createStanding(deckPokemon = listOf("Pikachu"), wins = 4, losses = 3),
+                        createStanding(deckPokemon = listOf("Pikachu"), wins = 6, losses = 1),
+                        createStanding(deckPokemon = listOf("Charizard"), wins = 5, losses = 2),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 2
+                result[0].deckName shouldBe "Pikachu"
+                result[0].usageShare shouldBe "75.0%"
+                result[1].deckName shouldBe "Charizard"
+                result[1].usageShare shouldBe "25.0%"
+            }
+        }
+    }
+
+    Given("정렬 검증") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("사용률 내림차순으로 정렬되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(deckPokemon = listOf("Low"), wins = 5, losses = 2),
+                        createStanding(deckPokemon = listOf("High"), wins = 5, losses = 2),
+                        createStanding(deckPokemon = listOf("High"), wins = 4, losses = 3),
+                        createStanding(deckPokemon = listOf("High"), wins = 6, losses = 1),
+                        createStanding(deckPokemon = listOf("Medium"), wins = 5, losses = 2),
+                        createStanding(deckPokemon = listOf("Medium"), wins = 4, losses = 3),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 3
+                result.map { it.deckName } shouldContainExactly listOf("High", "Medium", "Low")
+                result[0].usageShare shouldBe "50.0%"
+                result[1].usageShare shouldBe "33.3%"
+                result[2].usageShare shouldBe "16.7%"
+            }
+        }
+    }
+
+    Given("빈 덱 포켓몬을 가진 순위 데이터") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("빈 덱 포켓몬은 필터링되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(deckPokemon = emptyList(), wins = 5, losses = 2),
+                        createStanding(deckPokemon = listOf("Pikachu"), wins = 4, losses = 3),
+                        createStanding(deckPokemon = emptyList(), wins = 6, losses = 1),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 1
+                result[0].deckName shouldBe "Pikachu"
+                result[0].usageShare shouldBe "100.0%"
+            }
+        }
+    }
+
+    Given("실제 토너먼트 시나리오") {
+        When("다양한 덱과 플레이어가 있는 토너먼트 데이터") {
+            Then("현실적인 메타 스냅샷을 생성해야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("regional-1"),
+                        createTournamentId("regional-2"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("regional-1", "regional-2")) } returns
+                    listOf(
+                        createStanding(
+                            placing = 1,
+                            playerName = "Player1",
+                            deckPokemon = listOf("Pikachu ex", "Mewtwo ex"),
+                            wins = 6,
+                            losses = 1,
+                        ),
+                        createStanding(
+                            placing = 2,
+                            playerName = "Player2",
+                            deckPokemon = listOf("Charizard ex"),
+                            wins = 5,
+                            losses = 2,
+                        ),
+                        createStanding(
+                            placing = 3,
+                            playerName = "Player3",
+                            deckPokemon = listOf("Mewtwo ex", "Pikachu ex"),
+                            wins = 5,
+                            losses = 2,
+                        ),
+                        createStanding(
+                            placing = 4,
+                            playerName = "Player4",
+                            deckPokemon = listOf("Charizard ex"),
+                            wins = 4,
+                            losses = 3,
+                        ),
+                        createStanding(
+                            placing = 5,
+                            playerName = "Player5",
+                            deckPokemon = listOf("Pikachu ex", "Mewtwo ex"),
+                            wins = 4,
+                            losses = 3,
+                        ),
+                        createStanding(
+                            placing = 6,
+                            playerName = "Player6",
+                            deckPokemon = listOf("Articuno ex", "Starmie ex"),
+                            wins = 3,
+                            losses = 4,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 3
+                result[0].deckName shouldBe "Mewtwo ex + Pikachu ex"
+                result[0].appearances shouldBe 3
+                result[0].usageShare shouldBe "50.0%"
+                result[1].deckName shouldBe "Charizard ex"
+                result[1].appearances shouldBe 2
+                result[1].usageShare shouldBe "33.3%"
+                result[2].deckName shouldBe "Articuno ex + Starmie ex"
+                result[2].appearances shouldBe 1
+                result[2].usageShare shouldBe "16.7%"
+            }
+        }
+    }
+
+    Given("단일 토너먼트 ID") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("올바르게 처리되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("single-tournament"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("single-tournament")) } returns
+                    listOf(
+                        createStanding(
+                            deckPokemon = listOf("Pikachu"),
+                            wins = 6,
+                            losses = 1,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 1
+                result[0].deckName shouldBe "Pikachu"
+                coVerify(exactly = 1) { mockDataSource.getTop8Standings(listOf("single-tournament")) }
+            }
+        }
+    }
+
+    Given("복수 토너먼트 ID") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("모든 토너먼트 ID가 전달되어야 한다") {
+                val tournamentIds =
+                    listOf(
+                        createTournamentId("t1"),
+                        createTournamentId("t2"),
+                        createTournamentId("t3"),
+                        createTournamentId("t4"),
+                        createTournamentId("t5"),
+                    )
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns tournamentIds
+                coEvery { mockDataSource.getTop8Standings(any()) } returns emptyList()
+
+                repo.getDeckStatistics()
+
+                coVerify(exactly = 1) {
+                    mockDataSource.getTop8Standings(listOf("t1", "t2", "t3", "t4", "t5"))
+                }
+            }
+        }
+    }
+
+    Given("동일한 사용률에서 승률이 다른 덱들") {
+        When("getDeckStatistics를 호출할 때") {
+            Then("승률 내림차순으로 2차 정렬되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("t1"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("t1")) } returns
+                    listOf(
+                        createStanding(deckPokemon = listOf("Low WR"), wins = 3, losses = 7),
+                        createStanding(deckPokemon = listOf("High WR"), wins = 7, losses = 3),
+                        createStanding(deckPokemon = listOf("Medium WR"), wins = 5, losses = 5),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 3
+                result.map { it.deckName } shouldContainExactly listOf("High WR", "Medium WR", "Low WR")
+                result[0].winRate shouldBe "70.0%"
+                result[1].winRate shouldBe "50.0%"
+                result[2].winRate shouldBe "30.0%"
+            }
+        }
+    }
+
+    Given("파이프라인 통합 검증") {
+        When("전체 파이프라인이 실행될 때") {
+            Then("각 단계가 올바르게 연결되어야 한다") {
+                coEvery { mockDataSource.getQualifyingTournamentIds() } returns
+                    listOf(
+                        createTournamentId("pipeline-test"),
+                    )
+                coEvery { mockDataSource.getTop8Standings(listOf("pipeline-test")) } returns
+                    listOf(
+                        createStanding(
+                            deckPokemon = listOf("Pikachu", "Mewtwo"),
+                            wins = 10,
+                            losses = 5,
+                        ),
+                        createStanding(
+                            deckPokemon = listOf("Mewtwo", "Pikachu"),
+                            wins = 8,
+                            losses = 7,
+                        ),
+                    )
+
+                val result = repo.getDeckStatistics()
+
+                result shouldHaveSize 1
+                result[0].deckId shouldBe "Mewtwo|Pikachu"
+                result[0].deckName shouldBe "Mewtwo + Pikachu"
+                result[0].appearances shouldBe 2
+                result[0].winRate shouldBe "60.0%"
+                result[0].usageShare shouldBe "100.0%"
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary

Implements the repository layer that orchestrates the entire tournament deck statistics pipeline, completing issue #28. This repository ties together tournament data fetching, standings collection, deck aggregation, and win rate calculation into a cohesive API for ViewModels.

## Changes

- Create `TournamentStatsRepo` interface with `getDeckStatistics()` method
- Implement `DefaultTournamentStatsRepo` orchestrating full data pipeline
- Add comprehensive test suite with 16 test scenarios
- Follow existing `CardsRepo` and `DecksRepo` patterns for consistency
- Update MVP progress checklist marking infrastructure complete

## Implementation Details

### Repository Interface
- `TournamentStatsRepo.getDeckStatistics(): List<CalculatedDeck>`
- Suspending function for asynchronous operation
- Returns calculated deck statistics with win rates and usage shares

### Pipeline Orchestration
`DefaultTournamentStatsRepo` coordinates the complete data flow:
1. Fetch qualifying tournament IDs via `RemoteTournamentDataSource`
2. Collect top 8 standings for all tournaments
3. Aggregate standings by deck using `DeckStatsAggregator`
4. Calculate win rates and usage shares using `DeckStatsCalculator`
5. Return sorted list (by usage share, then win rate)

### Integration
- Uses `RemoteTournamentDataSource` (from issues #24-25)
- Uses `DeckStatsAggregator` (from issue #26)
- Uses `DeckStatsCalculator` (from issue #27)
- Follows existing repository patterns from `CardsRepo`

### Test Coverage
Created `DefaultTournamentStatsRepoTest` with 16 comprehensive scenarios:
- Basic pipeline integration with multiple decks
- Empty cases (no tournaments, no standings)
- Single deck scenarios (100% usage share)
- Multiple deck scenarios with sorting verification
- Method call verification with MockK
- Data mapping validation (deckId, deckName, winRate, usageShare)
- Real-world tournament meta simulations

All tests use Kotest BehaviorSpec with Korean descriptions matching project style.

## Testing

- [x] Unit tests written (16 scenarios)
- [x] Tests passing (all 62 tests pass)
- [x] Linting passing (ktlint checks pass)
- [x] Build successful

## Related Issues

Closes #28