### PR TITLE
test(viewmodel): add comprehensive test coverage for TierDecksViewModel

### DIFF
--- a/app/src/test/java/tcg/pocket/dex/tierdecks/TierDecksViewModelTest.kt
+++ b/app/src/test/java/tcg/pocket/dex/tierdecks/TierDecksViewModelTest.kt
@@ -68,6 +68,68 @@ class TierDecksViewModelTest : BehaviorSpec({
                 }
             }
         }
+
+        When("여러 덱을 순차적으로 확장하면") {
+            Then("각 덱이 독립적으로 확장되어야 한다") {
+                runTest(testDispatcher) {
+                    val viewModel = TierDecksViewModel(decksRepo = FakeDecksRepo())
+                    advanceUntilIdle()
+
+                    val successState = viewModel.uiState.value as UiState.Success
+                    val firstDeck = successState.data.first()
+                    val secondDeck = successState.data[1]
+
+                    viewModel.onExpandDeck(firstDeck)
+                    val afterFirst = viewModel.uiState.value as UiState.Success
+                    afterFirst.data.first().expanded shouldBe true
+
+                    viewModel.onExpandDeck(secondDeck)
+                    val afterSecond = viewModel.uiState.value as UiState.Success
+                    afterSecond.data.first().expanded shouldBe true
+                    afterSecond.data[1].expanded shouldBe true
+                }
+            }
+        }
+
+        When("확장된 덱을 다시 클릭하면") {
+            Then("덱이 접혀야 한다") {
+                runTest(testDispatcher) {
+                    val viewModel = TierDecksViewModel(decksRepo = FakeDecksRepo())
+                    advanceUntilIdle()
+
+                    val successState = viewModel.uiState.value as UiState.Success
+                    val deckItemState = successState.data.first()
+
+                    viewModel.onExpandDeck(deckItemState)
+                    val afterExpand = viewModel.uiState.value as UiState.Success
+                    val expandedDeck = afterExpand.data.first()
+                    expandedDeck.expanded shouldBe true
+
+                    viewModel.onExpandDeck(expandedDeck)
+                    val afterCollapse = viewModel.uiState.value as UiState.Success
+                    afterCollapse.data.first().expanded shouldBe false
+                }
+            }
+        }
+    }
+
+    Given("TierDecksViewModel with empty DecksRepo") {
+        val mockDecksRepo = mockk<DecksRepo>()
+
+        When("DecksRepo가 빈 리스트를 반환하면") {
+            Then("Error 상태가 되어야 한다") {
+                runTest(testDispatcher) {
+                    coEvery { mockDecksRepo.allTierDecks() } returns emptyList()
+
+                    val viewModel = TierDecksViewModel(decksRepo = mockDecksRepo)
+                    advanceUntilIdle()
+
+                    val state = viewModel.uiState.value
+                    state.shouldBeInstanceOf<UiState.Error>()
+                    (state as UiState.Error).message shouldBe "데이터를 찾을 수 없습니다"
+                }
+            }
+        }
     }
 
     Given("TierDecksViewModel with error-throwing DecksRepo") {
@@ -84,6 +146,21 @@ class TierDecksViewModelTest : BehaviorSpec({
                     val state = viewModel.uiState.value
                     state.shouldBeInstanceOf<UiState.Error>()
                     (state as UiState.Error).message shouldBe "Network error"
+                }
+            }
+        }
+
+        When("예외 메시지가 null이면") {
+            Then("기본 에러 메시지를 사용해야 한다") {
+                runTest(testDispatcher) {
+                    coEvery { mockDecksRepo.allTierDecks() } throws RuntimeException()
+
+                    val viewModel = TierDecksViewModel(decksRepo = mockDecksRepo)
+                    advanceUntilIdle()
+
+                    val state = viewModel.uiState.value
+                    state.shouldBeInstanceOf<UiState.Error>()
+                    (state as UiState.Error).message shouldBe "Unknown error"
                 }
             }
         }


### PR DESCRIPTION
## 요약

Issue #40의 모든 구현이 이미 완료되었음을 확인하고, 누락된 테스트 커버리지를 추가했습니다.

## 발견 사항

### ✅ 이미 구현 완료된 기능들

모든 Issue #40의 acceptance criteria가 이미 구현되어 있었습니다:

- ✅ `DecksRepo.allTierDecks()`가 suspend 함수로 변환됨
- ✅ `UiState` sealed interface 정의 완료 (Loading, Success, Error)
- ✅ `TierDecksViewModel`이 viewModelScope 사용
- ✅ 에러 발생 시 Error 상태로 전환
- ✅ `TierDecksScreen`에서 Loading/Error 상태 UI 표시
- ✅ `FakeDecksRepo`가 suspend 함수로 변환됨
- ✅ `DefaultDecksRepo`에서 runBlocking 제거됨

**구현 완료 커밋**: `587cce4` - "refactor(repo): convert DecksRepo to suspend functions"

### 📊 추가된 테스트 커버리지

기존 테스트에서 누락된 엣지 케이스들을 추가:

1. **빈 덱 리스트 처리** - 덱 데이터가 없을 때 에러 상태로 전환 확인
2. **다중 덱 확장** - 여러 덱을 독립적으로 확장할 수 있는지 확인
3. **덱 접기 동작** - 확장된 덱을 다시 클릭하여 접을 수 있는지 확인
4. **Null 예외 메시지** - 예외 메시지가 null일 때 기본 메시지 사용 확인

## 변경 사항

- `TierDecksViewModelTest.kt`에 4개의 새로운 테스트 케이스 추가 (+77 lines)

## 구현 세부사항

### 추가된 테스트

**1. 빈 덱 리스트 에러 처리**
```kotlin
Given("TierDecksViewModel with empty DecksRepo") {
    When("DecksRepo가 빈 리스트를 반환하면") {
        Then("Error 상태가 되어야 한다")
    }
}
```

**2. 다중 덱 확장**
```kotlin
When("여러 덱을 순차적으로 확장하면") {
    Then("각 덱이 독립적으로 확장되어야 한다")
}
```

**3. 덱 접기 동작**
```kotlin
When("확장된 덱을 다시 클릭하면") {
    Then("덱이 접혀야 한다")
}
```

**4. Null 예외 메시지 처리**
```kotlin
When("예외 메시지가 null이면") {
    Then("기본 에러 메시지를 사용해야 한다")
}
```

### 테스트 프레임워크

- **Kotest BehaviorSpec**: Given-When-Then 스타일의 BDD 테스트
- **MockK**: 에러 시나리오 모의 객체 생성
- **Coroutine Test**: `runTest`, `advanceUntilIdle`로 비동기 테스트

## 테스트

- [x] 유닛 테스트 작성 완료 (4 → 8 test cases)
- [x] 테스트 통과 확인 (✅ BUILD SUCCESSFUL in 17s)
- [x] 린트 검사 통과 (✅ BUILD SUCCESSFUL in 15s)
- [x] 빌드 성공 확인 (✅ BUILD SUCCESSFUL in 14s)

## 테스트 커버리지

| 시나리오 | 커버리지 상태 | 테스트 케이스 |
|---------|-----------|------------|
| 성공 상태 전환 | ✅ 완료 | 기존 + 신규 |
| 에러 상태 전환 | ✅ 완료 | 기존 + 신규 |
| 빈 데이터 처리 | ✅ 추가 | **신규** |
| 단일 덱 확장 | ✅ 완료 | 기존 |
| 다중 덱 확장 | ✅ 추가 | **신규** |
| 덱 접기 동작 | ✅ 추가 | **신규** |
| Null 예외 메시지 | ✅ 추가 | **신규** |

**전체 커버리지**: 4 테스트 → 8 테스트 (100% 증가)

## 관련 이슈

Closes #40