### PR TITLE
refactor(domain): deckId 파싱 로직을 도메인 레이어로 이동

### DIFF
--- a/app/src/main/java/tcg/pocket/dex/CalculatedDeck.kt
+++ b/app/src/main/java/tcg/pocket/dex/CalculatedDeck.kt
@@ -23,4 +23,7 @@ data class CalculatedDeck(
     init {
         require(appearances >= 0) { "Appearances must be non-negative, but was $appearances" }
     }
+
+    val pokemonNames: List<String>
+        get() = deckId.split("|").filter { it.isNotBlank() }
 }

--- a/app/src/main/java/tcg/pocket/dex/deckdetail/DeckDetailViewModel.kt
+++ b/app/src/main/java/tcg/pocket/dex/deckdetail/DeckDetailViewModel.kt
@@ -39,10 +39,7 @@ class DeckDetailViewModel(
                         tournamentStatsRepo.getDeckById(deckId)
                             ?: throw IllegalArgumentException("Deck not found: $deckId")
 
-                    val pokemonNames =
-                        deck.deckId
-                            .split("|")
-                            .filter { it.isNotBlank() }
+                    val pokemonNames = deck.pokemonNames
                     Timber.d("Loading cards for Pokemon: $pokemonNames")
 
                     val pokemonCards =

--- a/app/src/test/java/tcg/pocket/dex/CalculatedDeckTest.kt
+++ b/app/src/test/java/tcg/pocket/dex/CalculatedDeckTest.kt
@@ -426,4 +426,126 @@ class CalculatedDeckTest : BehaviorSpec({
             }
         }
     }
+
+    Given("pokemonNames computed property") {
+        When("deckId에 단일 포켓몬이 있을 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "Pikachu",
+                    deckName = "Pikachu Deck",
+                    winRate = "50.0%",
+                    usageShare = "10.0%",
+                    appearances = 50,
+                )
+
+            Then("포켓몬 이름 리스트를 반환해야 한다") {
+                deck.pokemonNames shouldBe listOf("Pikachu")
+            }
+        }
+
+        When("deckId에 여러 포켓몬이 파이프로 구분되어 있을 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "Pikachu|Mewtwo|Charizard",
+                    deckName = "Multi Pokemon Deck",
+                    winRate = "55.0%",
+                    usageShare = "25.0%",
+                    appearances = 100,
+                )
+
+            Then("모든 포켓몬 이름을 파싱해야 한다") {
+                deck.pokemonNames shouldBe listOf("Pikachu", "Mewtwo", "Charizard")
+            }
+        }
+
+        When("deckId가 빈 문자열일 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "",
+                    deckName = "Empty Deck",
+                    winRate = "0.0%",
+                    usageShare = "0.0%",
+                    appearances = 0,
+                )
+
+            Then("빈 리스트를 반환해야 한다") {
+                deck.pokemonNames shouldBe emptyList()
+            }
+        }
+
+        When("deckId에 빈 문자열 항목이 포함되어 있을 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "Pikachu||Mewtwo",
+                    deckName = "Deck with Empty Entry",
+                    winRate = "50.0%",
+                    usageShare = "15.0%",
+                    appearances = 75,
+                )
+
+            Then("빈 문자열은 필터링되어야 한다") {
+                deck.pokemonNames shouldBe listOf("Pikachu", "Mewtwo")
+            }
+        }
+
+        When("deckId가 파이프만 있을 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "|||",
+                    deckName = "Only Pipes",
+                    winRate = "0.0%",
+                    usageShare = "0.0%",
+                    appearances = 0,
+                )
+
+            Then("빈 리스트를 반환해야 한다") {
+                deck.pokemonNames shouldBe emptyList()
+            }
+        }
+
+        When("deckId에 단일 파이프가 있을 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "|",
+                    deckName = "Single Pipe",
+                    winRate = "0.0%",
+                    usageShare = "0.0%",
+                    appearances = 0,
+                )
+
+            Then("빈 리스트를 반환해야 한다") {
+                deck.pokemonNames shouldBe emptyList()
+            }
+        }
+
+        When("deckId에 앞뒤로 빈 문자열이 있을 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "|Pikachu|Mewtwo|",
+                    deckName = "Leading and Trailing Pipes",
+                    winRate = "50.0%",
+                    usageShare = "20.0%",
+                    appearances = 80,
+                )
+
+            Then("앞뒤 빈 문자열은 필터링되어야 한다") {
+                deck.pokemonNames shouldBe listOf("Pikachu", "Mewtwo")
+            }
+        }
+
+        When("실제 덱 ID 형식을 사용할 때") {
+            val deck =
+                CalculatedDeck(
+                    deckId = "Pikachu ex|Mewtwo ex",
+                    deckName = "Pikachu ex + Mewtwo ex",
+                    winRate = "54.7%",
+                    usageShare = "32.1%",
+                    appearances = 456,
+                )
+
+            Then("ex 포함된 이름도 정확히 파싱해야 한다") {
+                deck.pokemonNames shouldBe listOf("Pikachu ex", "Mewtwo ex")
+            }
+        }
+    }
 })


### PR DESCRIPTION
## 요약

Issue #51 해결: `deckId` 파싱 비즈니스 로직을 ViewModel에서 domain model로 이동하여 Single Responsibility Principle을 준수합니다.

## 변경 사항

### 1. Domain Layer 개선
- `CalculatedDeck`에 `pokemonNames` computed property 추가
- deckId를 파이프(`|`)로 분리하고 빈 문자열 필터링

### 2. ViewModel 단순화  
- `DeckDetailViewModel`에서 파싱 로직 제거
- `deck.pokemonNames` 직접 사용으로 4줄 → 1줄 간소화

### 3. 테스트 추가
- 8개의 포괄적인 테스트 시나리오 추가
- Edge case 완전 커버리지 (empty, blank, pipes 등)
- BehaviorSpec 패턴 준수

## 구현 세부사항

**Computed Property Pattern**:
```kotlin
val pokemonNames: List<String>
    get() = deckId.split("|").filter { it.isNotBlank() }
```

**Before** (ViewModel에 비즈니스 로직):
```kotlin
val pokemonNames = deck.deckId.split("|").filter { it.isNotBlank() }
```

**After** (Domain property 사용):
```kotlin
val pokemonNames = deck.pokemonNames
```

## 테스트

- [x] 유닛 테스트 작성 완료 (8개 시나리오)
- [x] 테스트 통과 확인
- [x] 린트 검사 통과
- [x] 빌드 성공 확인

### 테스트 커버리지:
1. 단일 포켓몬: `"Pikachu" → ["Pikachu"]`
2. 여러 포켓몬: `"Pikachu|Mewtwo|Charizard" → [...] `
3. 빈 deckId: `"" → []`
4. 빈 항목 필터링: `"Pikachu||Mewtwo" → ["Pikachu", "Mewtwo"]`
5. 파이프만: `"|||" → []`
6. 단일 파이프: `"|" → []`
7. 앞뒤 파이프: `"|Pikachu|Mewtwo|" → ["Pikachu", "Mewtwo"]`
8. 실제 덱 형식: `"Pikachu ex|Mewtwo ex" → ["Pikachu ex", "Mewtwo ex"]`

## 관련 이슈

Closes #51